### PR TITLE
Improve indexing reliability and add cancellable background jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `search-notes` auto-refresh now respects `INDEX_TTL` (disabled when unset)
 - Auto-refresh now fails open: if refresh fails or times out, search continues using stale index instead of returning an error
 - Incremental index and refresh change detection now use metadata-only index reads instead of full record loads
-- `index-notes` now supports `background` mode and defaults full indexing to background execution
+- `index-notes` supports explicit `background` mode while keeping synchronous default behavior for backward compatibility
 - CRUD operations now return richer note metadata (including note ID) for robust index synchronization
 - Background job progress is now granular (phase and batch based) instead of mostly static
 - Background jobs now support `cancelling` and `cancelled` states

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `SEARCH_REFRESH_TIMEOUT_MS` environment variable to cap how long `search-notes` waits for auto-refresh
+- TTL refresh policy module with focused tests (`refresh-policy`)
+- Background index job manager with `start-index-job`, `get-index-job`, and `list-index-jobs`
+- `cancel-index-job` for best-effort cancellation of running background jobs
+- `INDEX_JOB_RETENTION_SECONDS` environment variable for index job history retention
+- Post-write index sync layer for create/update/delete/move operations
+- Shared indexing progress/cancellation contracts for job orchestration
+
+### Changed
+
+- `search-notes` auto-refresh now respects `INDEX_TTL` (disabled when unset)
+- Auto-refresh now fails open: if refresh fails or times out, search continues using stale index instead of returning an error
+- Incremental index and refresh change detection now use metadata-only index reads instead of full record loads
+- `index-notes` now supports `background` mode and defaults full indexing to background execution
+- CRUD operations now return richer note metadata (including note ID) for robust index synchronization
+- Background job progress is now granular (phase and batch based) instead of mostly static
+- Background jobs now support `cancelling` and `cancelled` states
+
 ## [1.7.0] - 2026-01-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ For large vaults, prefer background indexing:
 mode: "full"               # full or incremental
 ```
 
-Returns job snapshot including `id`, `status`, and `progress`.
-Progress updates in smaller steps across fetch/embed/persist phases.
+Returns a job snapshot with `id`, `status`, and `progress`.
+Progress updates in smaller steps across fetch, embed, and persist phases.
 
 #### `get-index-job`
 
@@ -197,7 +197,7 @@ job_id: "<job-id>"
 ```
 
 Poll until status is `completed`, `failed`, or `cancelled`.
-You may also see the transitional status `cancelling`.
+You may see `cancelling` as a transitional status.
 
 #### `list-index-jobs`
 
@@ -214,7 +214,7 @@ job_id: "<job-id>"
 Requests best-effort cancellation for a running job. Cancellation is cooperative:
 - A long-running step must reach a cancellation checkpoint.
 - Partial work may remain.
-- You can safely start a new job after status becomes `cancelled`.
+- Start a new job after the current one reaches `cancelled`.
 
 #### `reindex-note`
 Re-index a single note after manual edits.
@@ -234,8 +234,8 @@ content: "# Heading\n\nMarkdown content..."
 folder: "Work"            # optional, defaults to Notes
 ```
 
-After create/update/delete/move, the server auto-syncs vector and chunk indexes in best-effort mode.
-If sync partially fails, the tool response includes an `index sync warning`; run `reindex-note` or `index-notes`.
+After create, update, delete, or move, the server auto-syncs vector and chunk indexes in best-effort mode.
+If sync partly fails, the tool response includes an `index sync warning`. Run `reindex-note` or `index-notes`.
 
 #### `update-note`
 Update an existing note.
@@ -385,13 +385,13 @@ Set `READONLY_MODE=false` in `.env` to enable write operations.
 Run `index-notes` to update the search index. Use `mode: full` if incremental misses changes.
 
 ### "iCloud account not available" / `Can't get account "iCloud"`
-This error is from a different Apple Notes MCP implementation that uses tool name `search_notes` and argument `Keywords`.
+This error comes from a different Apple Notes MCP implementation that uses tool `search_notes` and argument `Keywords`.
 
 This project uses:
 - tool: `search-notes`
 - argument: `query`
 
-If your client calls `search_notes` with `Keywords`, update the MCP server config to point to `apple-notes-mcp` and restart your MCP client.
+If your client calls `search_notes` with `Keywords`, point your MCP config to `apple-notes-mcp` and restart the client.
 
 ### JXA errors
 Ensure Apple Notes runs and contains notes. Grant automation permissions when prompted.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ MCP server for Apple Notes with semantic search and CRUD operations. Claude sear
 - **Semantic Search** - Find notes by meaning, not keywords
 - **Full CRUD** - Create, read, update, delete, and move notes
 - **Incremental Indexing** - Re-embed only changed notes
+- **Background Index Jobs** - Async full/incremental indexing with progress polling
 - **Dual Embedding** - Local HuggingFace or OpenRouter API
 
 ## What's New in 1.7
@@ -76,9 +77,18 @@ Configuration stored in `~/.apple-notes-mcp/.env`:
 | `EMBEDDING_MODEL` | Model name (local or OpenRouter) | `Xenova/multilingual-e5-small` |
 | `EMBEDDING_DIMS` | Embedding dimensions | `4096` |
 | `READONLY_MODE` | Block all write operations | `false` |
-| `INDEX_TTL` | Auto-reindex interval in seconds | - |
+| `INDEX_TTL` | Auto-refresh-on-search interval in seconds (disabled when unset) | - |
+| `SEARCH_REFRESH_TIMEOUT_MS` | Max time search waits for refresh before using stale index | `2000` |
+| `INDEX_JOB_RETENTION_SECONDS` | How long completed/failed index jobs remain queryable | `3600` |
 | `EMBEDDING_BATCH_SIZE` | Batch size for embedding generation | `50` |
 | `DEBUG` | Enable debug logging | `false` |
+
+### Search Auto-Refresh Policy
+
+- `search-notes` does **not** force refresh on every request.
+- If `INDEX_TTL` is unset, auto-refresh is disabled and search uses the current index.
+- If `INDEX_TTL` is set, refresh runs only after TTL expiration.
+- If refresh fails or takes longer than `SEARCH_REFRESH_TIMEOUT_MS`, search falls back to stale index results instead of timing out.
 
 To reconfigure:
 
@@ -164,9 +174,47 @@ Index notes for semantic search.
 ```
 mode: "incremental"       # incremental (default) or full
 force: false              # force reindex even if TTL hasn't expired
+background: true          # optional; defaults to true for full mode
 ```
 
 Use `mode: "full"` to create the chunk index for better long-note search. First full index takes longer as it generates chunks, but subsequent searches run fast.
+
+For large vaults, prefer background indexing:
+
+#### `start-index-job`
+
+```
+mode: "full"               # full or incremental
+```
+
+Returns job snapshot including `id`, `status`, and `progress`.
+Progress updates in smaller steps across fetch/embed/persist phases.
+
+#### `get-index-job`
+
+```
+job_id: "<job-id>"
+```
+
+Poll until status is `completed`, `failed`, or `cancelled`.
+You may also see the transitional status `cancelling`.
+
+#### `list-index-jobs`
+
+```
+limit: 10                  # optional, 1-50
+```
+
+#### `cancel-index-job`
+
+```
+job_id: "<job-id>"
+```
+
+Requests best-effort cancellation for a running job. Cancellation is cooperative:
+- A long-running step must reach a cancellation checkpoint.
+- Partial work may remain.
+- You can safely start a new job after status becomes `cancelled`.
 
 #### `reindex-note`
 Re-index a single note after manual edits.
@@ -185,6 +233,9 @@ title: "New Note"
 content: "# Heading\n\nMarkdown content..."
 folder: "Work"            # optional, defaults to Notes
 ```
+
+After create/update/delete/move, the server auto-syncs vector and chunk indexes in best-effort mode.
+If sync partially fails, the tool response includes an `index sync warning`; run `reindex-note` or `index-notes`.
 
 #### `update-note`
 Update an existing note.
@@ -332,6 +383,15 @@ Set `READONLY_MODE=false` in `.env` to enable write operations.
 
 ### Notes missing from search
 Run `index-notes` to update the search index. Use `mode: full` if incremental misses changes.
+
+### "iCloud account not available" / `Can't get account "iCloud"`
+This error is from a different Apple Notes MCP implementation that uses tool name `search_notes` and argument `Keywords`.
+
+This project uses:
+- tool: `search-notes`
+- argument: `query`
+
+If your client calls `search_notes` with `Keywords`, update the MCP server config to point to `apple-notes-mcp` and restart your MCP client.
 
 ### JXA errors
 Ensure Apple Notes runs and contains notes. Grant automation permissions when prompted.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Index notes for semantic search.
 ```
 mode: "incremental"       # incremental (default) or full
 force: false              # force reindex even if TTL hasn't expired
-background: true          # optional; defaults to true for full mode
+background: false         # optional; defaults to false (synchronous mode)
 ```
 
 Use `mode: "full"` to create the chunk index for better long-note search. First full index takes longer as it generates chunks, but subsequent searches run fast.

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -19,6 +19,7 @@ export const RRF_K = 60; // Reciprocal Rank Fusion constant
 
 // Timeouts and retries
 export const OPENROUTER_TIMEOUT_MS = 30000;
+export const DEFAULT_SEARCH_REFRESH_TIMEOUT_MS = 2000;
 
 // Cache settings
 export const EMBEDDING_CACHE_MAX_SIZE = 1000;
@@ -51,6 +52,10 @@ export const DEFAULT_CHUNK_OVERLAP = 100;
 
 // Batch processing
 export const DEFAULT_EMBEDDING_BATCH_SIZE = 50;
+
+// Background indexing jobs
+export const DEFAULT_INDEX_JOB_RETENTION_SECONDS = 3600;
+export const MAX_INDEX_JOB_HISTORY = 100;
 
 /**
  * Get embedding batch size from environment or use default.

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -28,6 +28,8 @@ describe("validateEnv", () => {
     delete process.env.READONLY_MODE;
     delete process.env.EMBEDDING_DIMS;
     delete process.env.INDEX_TTL;
+    delete process.env.SEARCH_REFRESH_TIMEOUT_MS;
+    delete process.env.INDEX_JOB_RETENTION_SECONDS;
     const { validateEnv } = await import("./env.js");
     expect(() => validateEnv()).not.toThrow();
   });
@@ -52,6 +54,18 @@ describe("validateEnv", () => {
 
   it("validates DEBUG is boolean string", async () => {
     process.env.DEBUG = "yes";
+    const { validateEnv } = await import("./env.js");
+    expect(() => validateEnv()).toThrow();
+  });
+
+  it("validates SEARCH_REFRESH_TIMEOUT_MS is numeric", async () => {
+    process.env.SEARCH_REFRESH_TIMEOUT_MS = "not-a-number";
+    const { validateEnv } = await import("./env.js");
+    expect(() => validateEnv()).toThrow();
+  });
+
+  it("validates INDEX_JOB_RETENTION_SECONDS is numeric", async () => {
+    process.env.INDEX_JOB_RETENTION_SECONDS = "abc";
     const { validateEnv } = await import("./env.js");
     expect(() => validateEnv()).toThrow();
   });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -6,6 +6,8 @@ const EnvSchema = z.object({
   EMBEDDING_DIMS: z.string().regex(/^\d+$/).optional(),
   READONLY_MODE: z.enum(["true", "false"]).optional(),
   INDEX_TTL: z.string().regex(/^\d+$/).optional(),
+  SEARCH_REFRESH_TIMEOUT_MS: z.string().regex(/^\d+$/).optional(),
+  INDEX_JOB_RETENTION_SECONDS: z.string().regex(/^\d+$/).optional(),
   DEBUG: z.enum(["true", "false"]).optional(),
 });
 

--- a/src/db/lancedb.test.ts
+++ b/src/db/lancedb.test.ts
@@ -72,6 +72,20 @@ describe("LanceDBStore", () => {
       await store.index([createTestRecord("Existing")]);
       await expect(store.delete("Non Existent")).resolves.not.toThrow();
     });
+
+    it("deleteByIdAndFolderAndTitle removes only matching record", async () => {
+      const base = createTestRecord("Shared");
+      const other = { ...createTestRecord("Shared"), id: "other-id" };
+
+      await store.index([base, other]);
+      expect(await store.count()).toBe(2);
+
+      await store.deleteByIdAndFolderAndTitle(base.id, base.folder, base.title);
+
+      expect(await store.count()).toBe(1);
+      const remaining = await store.getByTitle("Shared");
+      expect(remaining?.id).toBe("other-id");
+    });
   });
 
   describe("getAll", () => {

--- a/src/db/lancedb.ts
+++ b/src/db/lancedb.ts
@@ -55,6 +55,7 @@ export interface VectorStore {
   update(record: NoteRecord): Promise<void>;
   delete(title: string): Promise<void>;
   deleteByFolderAndTitle(folder: string, title: string): Promise<void>;
+  deleteByIdAndFolderAndTitle(id: string, folder: string, title: string): Promise<void>;
   search(queryVector: number[], limit: number): Promise<SearchResult[]>;
   searchFTS(query: string, limit: number): Promise<SearchResult[]>;
   getByTitle(title: string): Promise<NoteRecord | null>;
@@ -257,6 +258,18 @@ export class LanceDBStore implements VectorStore {
     const escapedFolder = escapeForFilter(folder);
     await table.delete(`folder = '${escapedFolder}' AND title = '${escapedTitle}'`);
     debug(`Deleted record: ${folder}/${title}`);
+  }
+
+  async deleteByIdAndFolderAndTitle(id: string, folder: string, title: string): Promise<void> {
+    const table = await this.ensureTable();
+    const validTitle = validateTitle(title);
+    const escapedId = escapeForFilter(id);
+    const escapedTitle = escapeForFilter(validTitle);
+    const escapedFolder = escapeForFilter(folder);
+    await table.delete(
+      `id = '${escapedId}' AND folder = '${escapedFolder}' AND title = '${escapedTitle}'`
+    );
+    debug(`Deleted record by id: ${id} (${folder}/${title})`);
   }
 
   async search(queryVector: number[], limit: number): Promise<SearchResult[]> {

--- a/src/db/lancedb.ts
+++ b/src/db/lancedb.ts
@@ -20,6 +20,13 @@ export interface NoteRecord {
   [key: string]: unknown; // Index signature for LanceDB compatibility
 }
 
+export interface IndexMetadataRecord {
+  id: string;
+  title: string;
+  folder: string;
+  indexed_at: string;
+}
+
 // Schema for chunked notes (Parent Document Retriever pattern)
 export interface ChunkRecord {
   chunk_id: string;      // `${note_id}_chunk_${index}`
@@ -51,6 +58,7 @@ export interface VectorStore {
   search(queryVector: number[], limit: number): Promise<SearchResult[]>;
   searchFTS(query: string, limit: number): Promise<SearchResult[]>;
   getByTitle(title: string): Promise<NoteRecord | null>;
+  getIndexMetadata(): Promise<IndexMetadataRecord[]>;
   getAll(): Promise<NoteRecord[]>;
   count(): Promise<number>;
   clear(): Promise<void>;
@@ -293,6 +301,22 @@ export class LanceDBStore implements VectorStore {
     if (results.length === 0) return null;
 
     return results[0] as unknown as NoteRecord;
+  }
+
+  async getIndexMetadata(): Promise<IndexMetadataRecord[]> {
+    const table = await this.ensureTable();
+
+    const results = await table
+      .query()
+      .select(["id", "title", "folder", "indexed_at"])
+      .toArray();
+
+    return results.map((row): IndexMetadataRecord => ({
+      id: (row.id as string) ?? "",
+      title: row.title as string,
+      folder: row.folder as string,
+      indexed_at: row.indexed_at as string,
+    }));
   }
 
   async getAll(): Promise<NoteRecord[]> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,7 +280,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
             background: {
               type: "boolean",
-              description: "Run indexing as async background job (default: true for full mode)"
+              description: "Run indexing as async background job (default: false)"
             },
           },
           required: [],
@@ -673,7 +673,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const params = IndexNotesSchema.parse(args);
         const jobs = getIndexJobManager();
 
-        const runInBackground = params.background ?? (params.mode === "full");
+        const runInBackground = params.background ?? false;
         if (runInBackground) {
           const job = jobs.start({ mode: params.mode });
           return textResponse(

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,13 @@ import { indexNotes, reindexNote } from "./search/indexer.js";
 import { fullChunkIndex, hasChunkIndex } from "./search/chunk-indexer.js";
 import { searchChunks } from "./search/chunk-search.js";
 import { refreshIfNeeded } from "./search/refresh.js";
+import { getIndexJobManager } from "./indexing/job-manager.js";
+import {
+  syncAfterCreate,
+  syncAfterUpdate,
+  syncAfterDelete,
+  syncAfterMove,
+} from "./search/write-sync.js";
 import { listTags, searchByTag, findRelatedNotes } from "./graph/queries.js";
 import { exportGraph } from "./graph/export.js";
 import { findTables, parseTable } from "./notes/tables.js";
@@ -85,6 +92,23 @@ const SearchNotesSchema = z.object({
 const IndexNotesSchema = z.object({
   mode: z.enum(["full", "incremental"]).default("incremental"),
   force: z.boolean().default(false),
+  background: z.boolean().optional(),
+});
+
+const StartIndexJobSchema = z.object({
+  mode: z.enum(["full", "incremental"]).default("incremental"),
+});
+
+const GetIndexJobSchema = z.object({
+  job_id: z.string().min(1),
+});
+
+const ListIndexJobsSchema = z.object({
+  limit: z.number().min(1).max(50).default(10),
+});
+
+const CancelIndexJobSchema = z.object({
+  job_id: z.string().min(1),
 });
 
 const ReindexNoteSchema = z.object({
@@ -254,8 +278,69 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               type: "boolean",
               description: "Force reindex even if TTL hasn't expired (default: false)"
             },
+            background: {
+              type: "boolean",
+              description: "Run indexing as async background job (default: true for full mode)"
+            },
           },
           required: [],
+        },
+      },
+      {
+        name: "start-index-job",
+        description: "Start background indexing job and return job id for polling",
+        inputSchema: {
+          type: "object",
+          properties: {
+            mode: {
+              type: "string",
+              enum: ["full", "incremental"],
+              description: "Index mode (default: incremental)",
+            },
+          },
+          required: [],
+        },
+      },
+      {
+        name: "get-index-job",
+        description: "Get background indexing job status and progress",
+        inputSchema: {
+          type: "object",
+          properties: {
+            job_id: {
+              type: "string",
+              description: "Job ID returned from start-index-job or index-notes",
+            },
+          },
+          required: ["job_id"],
+        },
+      },
+      {
+        name: "list-index-jobs",
+        description: "List recent background indexing jobs",
+        inputSchema: {
+          type: "object",
+          properties: {
+            limit: {
+              type: "number",
+              description: "Max jobs to return (default: 10)",
+            },
+          },
+          required: [],
+        },
+      },
+      {
+        name: "cancel-index-job",
+        description: "Request cancellation for a running background indexing job",
+        inputSchema: {
+          type: "object",
+          properties: {
+            job_id: {
+              type: "string",
+              description: "Job ID returned from start-index-job or index-notes",
+            },
+          },
+          required: ["job_id"],
         },
       },
       {
@@ -586,6 +671,25 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       case "index-notes": {
         const params = IndexNotesSchema.parse(args);
+        const jobs = getIndexJobManager();
+
+        const runInBackground = params.background ?? (params.mode === "full");
+        if (runInBackground) {
+          const job = jobs.start({ mode: params.mode });
+          return textResponse(
+            JSON.stringify(
+              {
+                message: `Started ${params.mode} index job`,
+                job_id: job.id,
+                status: job.status,
+                progress: job.progress,
+              },
+              null,
+              2
+            )
+          );
+        }
+
         const result = await indexNotes(params.mode);
 
         let message = `Indexed ${result.indexed} notes in ${(result.timeMs / 1000).toFixed(1)}s`;
@@ -624,6 +728,40 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
 
         return textResponse(message);
+      }
+
+      case "start-index-job": {
+        const params = StartIndexJobSchema.parse(args);
+        const jobs = getIndexJobManager();
+        const job = jobs.start({ mode: params.mode });
+        return textResponse(JSON.stringify(job, null, 2));
+      }
+
+      case "get-index-job": {
+        const params = GetIndexJobSchema.parse(args);
+        const jobs = getIndexJobManager();
+        const job = jobs.get(params.job_id);
+        if (!job) {
+          return errorResponse(`Index job not found: "${params.job_id}"`);
+        }
+        return textResponse(JSON.stringify(job, null, 2));
+      }
+
+      case "list-index-jobs": {
+        const params = ListIndexJobsSchema.parse(args);
+        const jobs = getIndexJobManager();
+        const list = jobs.list(params.limit);
+        return textResponse(JSON.stringify(list, null, 2));
+      }
+
+      case "cancel-index-job": {
+        const params = CancelIndexJobSchema.parse(args);
+        const jobs = getIndexJobManager();
+        const job = jobs.cancel(params.job_id);
+        if (!job) {
+          return errorResponse(`Index job not found: "${params.job_id}"`);
+        }
+        return textResponse(JSON.stringify(job, null, 2));
       }
 
       case "reindex-note": {
@@ -726,9 +864,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // Write tools
       case "create-note": {
         const params = CreateNoteSchema.parse(args);
-        await createNote(params.title, params.content, params.folder);
-        const location = params.folder ? `${params.folder}/${params.title}` : params.title;
-        return textResponse(`Created note: "${location}"`);
+        const result = await createNote(params.title, params.content, params.folder);
+        const location = `${result.folder}/${result.title}`;
+
+        const syncResult = await syncAfterCreate(result);
+        const syncWarning = syncResult.warnings.length > 0
+          ? ` (index sync warning: ${syncResult.warnings.join("; ")})`
+          : "";
+
+        return textResponse(`Created note: "${location}"${syncWarning}`);
       }
 
       case "update-note": {
@@ -742,15 +886,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           : "";
 
         if (params.reindex) {
-          try {
-            // Use new title for reindexing (Apple Notes may have renamed it)
-            const reindexTitle = `${result.folder}/${result.newTitle}`;
-            await reindexNote(reindexTitle);
-            return textResponse(`Updated and reindexed note: "${location}"${renamedMsg}`);
-          } catch (reindexError) {
-            debug("Reindex after update failed:", reindexError);
-            return textResponse(`Updated note: "${location}"${renamedMsg} (reindexing failed, run index-notes to update)`);
-          }
+          const syncResult = await syncAfterUpdate(result);
+          const syncWarning = syncResult.warnings.length > 0
+            ? ` (index sync warning: ${syncResult.warnings.join("; ")})`
+            : "";
+          return textResponse(`Updated and reindexed note: "${location}"${renamedMsg}${syncWarning}`);
         }
 
         return textResponse(`Updated note: "${location}"${renamedMsg}`);
@@ -761,14 +901,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (!params.confirm) {
           return errorResponse("Add confirm: true to delete the note");
         }
-        await deleteNote(params.title);
-        return textResponse(`Deleted note: "${params.title}"`);
+        const result = await deleteNote(params.title);
+        const syncResult = await syncAfterDelete(result);
+        const syncWarning = syncResult.warnings.length > 0
+          ? ` (index sync warning: ${syncResult.warnings.join("; ")})`
+          : "";
+        return textResponse(`Deleted note: "${params.title}"${syncWarning}`);
       }
 
       case "move-note": {
         const params = MoveNoteSchema.parse(args);
-        await moveNote(params.title, params.folder);
-        return textResponse(`Moved note: "${params.title}" to folder "${params.folder}"`);
+        const result = await moveNote(params.title, params.folder);
+        const syncResult = await syncAfterMove(result);
+        const syncWarning = syncResult.warnings.length > 0
+          ? ` (index sync warning: ${syncResult.warnings.join("; ")})`
+          : "";
+        return textResponse(`Moved note: "${params.title}" to folder "${params.folder}"${syncWarning}`);
       }
 
       case "edit-table": {

--- a/src/indexing/contracts.test.ts
+++ b/src/indexing/contracts.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { IndexCancelledError, isIndexCancelledError } from "./contracts.js";
+
+describe("indexing contracts", () => {
+  it("creates cancellable error type", () => {
+    const err = new IndexCancelledError("user requested cancel");
+    expect(isIndexCancelledError(err)).toBe(true);
+  });
+
+  it("does not treat generic Error as cancelled", () => {
+    expect(isIndexCancelledError(new Error("x"))).toBe(false);
+  });
+});

--- a/src/indexing/contracts.ts
+++ b/src/indexing/contracts.ts
@@ -1,0 +1,28 @@
+export interface IndexProgressEvent {
+  stage: "fetch" | "prepare" | "embed" | "persist" | "delete" | "rebuild-fts" | "done";
+  current: number;
+  total: number;
+  message: string;
+}
+
+export interface IndexRunOptions {
+  signal?: AbortSignal;
+  onProgress?: (event: IndexProgressEvent) => void;
+}
+
+export class IndexCancelledError extends Error {
+  constructor(message = "Indexing cancelled") {
+    super(message);
+    this.name = "IndexCancelledError";
+  }
+}
+
+export function isIndexCancelledError(error: unknown): error is IndexCancelledError {
+  return error instanceof IndexCancelledError;
+}
+
+export function throwIfCancelled(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new IndexCancelledError();
+  }
+}

--- a/src/indexing/job-manager.test.ts
+++ b/src/indexing/job-manager.test.ts
@@ -67,6 +67,24 @@ describe("job-manager", () => {
     expect(first.id).toBe(second.id);
   });
 
+  it("deduplicates active jobs across modes", async () => {
+    const unresolved = new Promise(() => {
+      // keep running
+    });
+
+    const manager = createIndexJobManager({
+      indexNotes: vi.fn().mockReturnValue(unresolved),
+      fullChunkIndex: vi.fn(),
+      now: () => Date.now(),
+      newId: () => crypto.randomUUID(),
+    });
+
+    const full = manager.start({ mode: "full" });
+    const incremental = manager.start({ mode: "incremental" });
+
+    expect(incremental.id).toBe(full.id);
+  });
+
   it("tracks failed job state and error message", async () => {
     const manager = createIndexJobManager({
       indexNotes: vi.fn().mockRejectedValue(new Error("boom")),
@@ -138,5 +156,30 @@ describe("job-manager", () => {
   it("returns null when cancelling unknown job", async () => {
     const manager = createIndexJobManager();
     expect(manager.cancel("missing")).toBeNull();
+  });
+
+  it("does not start a queued job after cancel", async () => {
+    const indexNotes = vi.fn().mockResolvedValue({
+      total: 0,
+      indexed: 0,
+      errors: 0,
+      timeMs: 1,
+    });
+
+    const manager = createIndexJobManager({
+      indexNotes,
+      fullChunkIndex: vi.fn(),
+      now: () => Date.now(),
+      newId: () => "q1",
+    });
+
+    const started = manager.start({ mode: "incremental" });
+    const cancelled = manager.cancel(started.id);
+    expect(cancelled?.status).toBe("cancelled");
+
+    await flushPromises();
+
+    expect(indexNotes).not.toHaveBeenCalled();
+    expect(manager.get(started.id)?.status).toBe("cancelled");
   });
 });

--- a/src/indexing/job-manager.test.ts
+++ b/src/indexing/job-manager.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from "vitest";
+import { createIndexJobManager } from "./job-manager.js";
+import { IndexCancelledError } from "./contracts.js";
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("job-manager", () => {
+  it("starts a job and returns completed status", async () => {
+    const manager = createIndexJobManager({
+      indexNotes: vi.fn().mockImplementation(async (_mode, options) => {
+        options?.onProgress?.({
+          stage: "fetch",
+          current: 1,
+          total: 1,
+          message: "Fetched",
+        });
+        return {
+          total: 1,
+          indexed: 1,
+          errors: 0,
+          timeMs: 50,
+        };
+      }),
+      fullChunkIndex: vi.fn().mockResolvedValue({
+        totalNotes: 1,
+        totalChunks: 2,
+        indexed: 2,
+        timeMs: 30,
+      }),
+      now: () => Date.now(),
+      newId: () => "job-1",
+    });
+
+    const job = manager.start({ mode: "incremental" });
+    const initial = manager.get(job.id);
+    expect(initial?.status).toBe("queued");
+
+    await flushPromises();
+
+    const final = manager.get(job.id);
+    expect(final?.status).toBe("completed");
+    expect(final?.progress.percent).toBe(100);
+  });
+
+  it("deduplicates concurrent full jobs", async () => {
+    const unresolved = new Promise(() => {
+      // intentionally unresolved for dedupe check
+    });
+
+    const manager = createIndexJobManager({
+      indexNotes: vi.fn().mockReturnValue(unresolved),
+      fullChunkIndex: vi.fn().mockResolvedValue({
+        totalNotes: 1,
+        totalChunks: 1,
+        indexed: 1,
+        timeMs: 1,
+      }),
+      now: () => Date.now(),
+      newId: () => crypto.randomUUID(),
+    });
+
+    const first = manager.start({ mode: "full" });
+    const second = manager.start({ mode: "full" });
+    expect(first.id).toBe(second.id);
+  });
+
+  it("tracks failed job state and error message", async () => {
+    const manager = createIndexJobManager({
+      indexNotes: vi.fn().mockRejectedValue(new Error("boom")),
+      fullChunkIndex: vi.fn(),
+      now: () => Date.now(),
+      newId: () => "job-fail",
+    });
+
+    const job = manager.start({ mode: "incremental" });
+    await flushPromises();
+
+    const final = manager.get(job.id);
+    expect(final?.status).toBe("failed");
+    expect(final?.error).toBeTruthy();
+  });
+
+  it("updates running progress beyond initial 10 percent", async () => {
+    const manager = createIndexJobManager({
+      indexNotes: vi.fn().mockImplementation((_mode, options) => {
+        options?.onProgress?.({
+          stage: "embed",
+          current: 1,
+          total: 2,
+          message: "Embedded batch 1/2",
+        });
+
+        return new Promise(() => {
+          // keep running so we can inspect intermediate progress
+        });
+      }),
+      fullChunkIndex: vi.fn(),
+      now: () => Date.now(),
+      newId: () => "job-progress",
+    });
+
+    const job = manager.start({ mode: "incremental" });
+    await flushPromises();
+
+    const running = manager.get(job.id);
+    expect(running?.status).toBe("running");
+    expect((running?.progress.percent ?? 0)).toBeGreaterThan(10);
+  });
+
+  it("marks job as cancelled when cancel is requested", async () => {
+    const manager = createIndexJobManager({
+      indexNotes: vi.fn().mockImplementation((_mode, options) => {
+        return new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(new IndexCancelledError("cancelled"));
+          });
+        });
+      }),
+      fullChunkIndex: vi.fn(),
+      now: () => Date.now(),
+      newId: () => "job-cancel",
+    });
+
+    const started = manager.start({ mode: "incremental" });
+    await flushPromises();
+
+    const cancelling = manager.cancel(started.id);
+    expect(cancelling?.status).toBe("cancelling");
+
+    await flushPromises();
+    const cancelled = manager.get(started.id);
+    expect(cancelled?.status).toBe("cancelled");
+  });
+
+  it("returns null when cancelling unknown job", async () => {
+    const manager = createIndexJobManager();
+    expect(manager.cancel("missing")).toBeNull();
+  });
+});

--- a/src/indexing/job-manager.ts
+++ b/src/indexing/job-manager.ts
@@ -1,0 +1,374 @@
+import {
+  DEFAULT_INDEX_JOB_RETENTION_SECONDS,
+  MAX_INDEX_JOB_HISTORY,
+} from "../config/constants.js";
+import { indexNotes, type IndexResult } from "../search/indexer.js";
+import { fullChunkIndex, type ChunkIndexResult } from "../search/chunk-indexer.js";
+import {
+  type IndexProgressEvent,
+  type IndexRunOptions,
+  isIndexCancelledError,
+} from "./contracts.js";
+import { sanitizeErrorMessage } from "../utils/errors.js";
+import { createDebugLogger } from "../utils/debug.js";
+
+const debug = createDebugLogger("INDEX-JOBS");
+
+export type IndexJobStatus =
+  | "queued"
+  | "running"
+  | "cancelling"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+export interface IndexJobProgress {
+  phase: string;
+  percent: number;
+  message: string;
+}
+
+export interface IndexJob {
+  id: string;
+  mode: "full" | "incremental";
+  status: IndexJobStatus;
+  progress: IndexJobProgress;
+  createdAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  result?: IndexResult;
+  chunkResult?: ChunkIndexResult;
+  error?: string;
+}
+
+export interface StartIndexJobOptions {
+  mode: "full" | "incremental";
+}
+
+interface IndexJobManagerDeps {
+  indexNotes: (mode: "full" | "incremental", options?: IndexRunOptions) => Promise<IndexResult>;
+  fullChunkIndex: (options?: IndexRunOptions) => Promise<ChunkIndexResult>;
+  now: () => number;
+  newId: () => string;
+}
+
+export interface IndexJobManager {
+  start: (options: StartIndexJobOptions) => IndexJob;
+  get: (jobId: string) => IndexJob | null;
+  list: (limit?: number) => IndexJob[];
+  cancel: (jobId: string) => IndexJob | null;
+}
+
+function cloneJob(job: IndexJob): IndexJob {
+  return {
+    ...job,
+    progress: { ...job.progress },
+  };
+}
+
+function getRetentionSeconds(): number {
+  const raw = process.env.INDEX_JOB_RETENTION_SECONDS;
+  if (!raw) return DEFAULT_INDEX_JOB_RETENTION_SECONDS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_INDEX_JOB_RETENTION_SECONDS;
+  }
+  return parsed;
+}
+
+function clampPercent(percent: number): number {
+  return Math.max(0, Math.min(100, Math.round(percent)));
+}
+
+function ratio(current: number, total: number): number {
+  if (total <= 0) return 0;
+  return Math.max(0, Math.min(1, current / total));
+}
+
+function mapProgressForIncremental(event: IndexProgressEvent): number {
+  switch (event.stage) {
+    case "fetch":
+      return 5 + ratio(event.current, event.total) * 15;
+    case "prepare":
+      return 20 + ratio(event.current, event.total) * 10;
+    case "embed":
+      return 30 + ratio(event.current, event.total) * 35;
+    case "persist":
+      return 65 + ratio(event.current, event.total) * 25;
+    case "delete":
+      return 75 + ratio(event.current, event.total) * 10;
+    case "rebuild-fts":
+      return 90 + ratio(event.current, event.total) * 9;
+    case "done":
+      return 99;
+    default:
+      return 10;
+  }
+}
+
+function mapProgressForFullNotes(event: IndexProgressEvent): number {
+  switch (event.stage) {
+    case "fetch":
+      return 5 + ratio(event.current, event.total) * 15;
+    case "prepare":
+      return 20 + ratio(event.current, event.total) * 10;
+    case "embed":
+      return 30 + ratio(event.current, event.total) * 20;
+    case "persist":
+      return 50 + ratio(event.current, event.total) * 15;
+    case "rebuild-fts":
+      return 65 + ratio(event.current, event.total) * 5;
+    case "done":
+      return 70;
+    default:
+      return 10;
+  }
+}
+
+function mapProgressForFullChunks(event: IndexProgressEvent): number {
+  switch (event.stage) {
+    case "fetch":
+      return 70 + ratio(event.current, event.total) * 5;
+    case "prepare":
+      return 75 + ratio(event.current, event.total) * 5;
+    case "embed":
+      return 80 + ratio(event.current, event.total) * 10;
+    case "persist":
+      return 90 + ratio(event.current, event.total) * 5;
+    case "done":
+      return 95;
+    default:
+      return 75;
+  }
+}
+
+export function createIndexJobManager(
+  deps: Partial<IndexJobManagerDeps> = {}
+): IndexJobManager {
+  const resolvedDeps: IndexJobManagerDeps = {
+    indexNotes,
+    fullChunkIndex,
+    now: () => Date.now(),
+    newId: () => crypto.randomUUID(),
+    ...deps,
+  };
+
+  const jobs = new Map<string, IndexJob>();
+  const order: string[] = [];
+  const controllers = new Map<string, AbortController>();
+
+  function prune(): void {
+    const retentionMs = getRetentionSeconds() * 1000;
+    const now = resolvedDeps.now();
+
+    for (const jobId of [...order]) {
+      const job = jobs.get(jobId);
+      if (!job) continue;
+
+      if (
+        (job.status === "completed" || job.status === "failed" || job.status === "cancelled") &&
+        job.finishedAt
+      ) {
+        const ageMs = now - Date.parse(job.finishedAt);
+        if (ageMs > retentionMs) {
+          jobs.delete(jobId);
+          controllers.delete(jobId);
+        }
+      }
+    }
+
+    const alive = order.filter((id) => jobs.has(id));
+    order.length = 0;
+    order.push(...alive);
+
+    while (order.length > MAX_INDEX_JOB_HISTORY) {
+      const oldest = order.shift();
+      if (oldest) {
+        jobs.delete(oldest);
+        controllers.delete(oldest);
+      }
+    }
+  }
+
+  function getActiveJobByMode(mode: "full" | "incremental"): IndexJob | null {
+    for (let i = order.length - 1; i >= 0; i -= 1) {
+      const job = jobs.get(order[i]);
+      if (!job) continue;
+      if (
+        job.mode === mode &&
+        (job.status === "queued" || job.status === "running" || job.status === "cancelling")
+      ) {
+        return job;
+      }
+    }
+    return null;
+  }
+
+  function setProgress(job: IndexJob, phase: string, percent: number, message: string): void {
+    job.progress = {
+      phase,
+      percent: clampPercent(percent),
+      message,
+    };
+  }
+
+  function noteProgressHandler(job: IndexJob) {
+    return (event: IndexProgressEvent): void => {
+      if (job.status === "cancelling") {
+        return;
+      }
+      const percent =
+        job.mode === "incremental"
+          ? mapProgressForIncremental(event)
+          : mapProgressForFullNotes(event);
+      setProgress(job, `indexing-notes/${event.stage}`, percent, event.message);
+    };
+  }
+
+  function chunkProgressHandler(job: IndexJob) {
+    return (event: IndexProgressEvent): void => {
+      if (job.status === "cancelling") {
+        return;
+      }
+      const percent = mapProgressForFullChunks(event);
+      setProgress(job, `indexing-chunks/${event.stage}`, percent, event.message);
+    };
+  }
+
+  async function run(jobId: string): Promise<void> {
+    const job = jobs.get(jobId);
+    if (!job) return;
+
+    const controller = new AbortController();
+    controllers.set(jobId, controller);
+
+    try {
+      job.status = "running";
+      job.startedAt = new Date(resolvedDeps.now()).toISOString();
+      setProgress(job, "indexing-notes", 5, `Running ${job.mode} index`);
+
+      const result = await resolvedDeps.indexNotes(job.mode, {
+        signal: controller.signal,
+        onProgress: noteProgressHandler(job),
+      });
+      job.result = result;
+
+      if (job.mode === "full") {
+        setProgress(job, "indexing-chunks", 70, "Building chunk index");
+        const chunkResult = await resolvedDeps.fullChunkIndex({
+          signal: controller.signal,
+          onProgress: chunkProgressHandler(job),
+        });
+        job.chunkResult = chunkResult;
+      }
+
+      job.status = "completed";
+      job.finishedAt = new Date(resolvedDeps.now()).toISOString();
+      setProgress(job, "completed", 100, "Index job completed");
+    } catch (error) {
+      const cancelled = controller.signal.aborted || isIndexCancelledError(error);
+      if (cancelled) {
+        job.status = "cancelled";
+        job.finishedAt = new Date(resolvedDeps.now()).toISOString();
+        setProgress(job, "cancelled", 100, "Index job cancelled");
+      } else {
+        job.status = "failed";
+        job.finishedAt = new Date(resolvedDeps.now()).toISOString();
+        job.error = sanitizeErrorMessage(error instanceof Error ? error.message : String(error));
+        setProgress(job, "failed", 100, "Index job failed");
+        debug("Background index job failed:", error);
+      }
+    } finally {
+      controllers.delete(jobId);
+      prune();
+    }
+  }
+
+  function start(options: StartIndexJobOptions): IndexJob {
+    prune();
+
+    const existing = getActiveJobByMode(options.mode);
+    if (existing) {
+      return cloneJob(existing);
+    }
+
+    const id = resolvedDeps.newId();
+    const job: IndexJob = {
+      id,
+      mode: options.mode,
+      status: "queued",
+      progress: {
+        phase: "queued",
+        percent: 0,
+        message: "Job queued",
+      },
+      createdAt: new Date(resolvedDeps.now()).toISOString(),
+    };
+
+    jobs.set(id, job);
+    order.push(id);
+
+    queueMicrotask(() => {
+      void run(id);
+    });
+
+    return cloneJob(job);
+  }
+
+  function get(jobId: string): IndexJob | null {
+    prune();
+    const job = jobs.get(jobId);
+    return job ? cloneJob(job) : null;
+  }
+
+  function list(limit = 10): IndexJob[] {
+    prune();
+    const boundedLimit = Math.max(1, Math.min(limit, 50));
+    const ids = [...order].reverse().slice(0, boundedLimit);
+    return ids
+      .map((id) => jobs.get(id))
+      .filter((job): job is IndexJob => job !== undefined)
+      .map(cloneJob);
+  }
+
+  function cancel(jobId: string): IndexJob | null {
+    prune();
+    const job = jobs.get(jobId);
+    if (!job) {
+      return null;
+    }
+
+    if (job.status === "completed" || job.status === "failed" || job.status === "cancelled") {
+      return cloneJob(job);
+    }
+
+    if (job.status === "queued") {
+      job.status = "cancelled";
+      job.finishedAt = new Date(resolvedDeps.now()).toISOString();
+      setProgress(job, "cancelled", 100, "Index job cancelled before start");
+      return cloneJob(job);
+    }
+
+    job.status = "cancelling";
+    setProgress(job, "cancelling", job.progress.percent, "Cancellation requested");
+    controllers.get(jobId)?.abort();
+
+    return cloneJob(job);
+  }
+
+  return {
+    start,
+    get,
+    list,
+    cancel,
+  };
+}
+
+let defaultManager: IndexJobManager | null = null;
+
+export function getIndexJobManager(): IndexJobManager {
+  if (!defaultManager) {
+    defaultManager = createIndexJobManager();
+  }
+  return defaultManager;
+}

--- a/src/indexing/job-manager.ts
+++ b/src/indexing/job-manager.ts
@@ -190,12 +190,11 @@ export function createIndexJobManager(
     }
   }
 
-  function getActiveJobByMode(mode: "full" | "incremental"): IndexJob | null {
+  function getActiveJob(): IndexJob | null {
     for (let i = order.length - 1; i >= 0; i -= 1) {
       const job = jobs.get(order[i]);
       if (!job) continue;
       if (
-        job.mode === mode &&
         (job.status === "queued" || job.status === "running" || job.status === "cancelling")
       ) {
         return job;
@@ -238,6 +237,10 @@ export function createIndexJobManager(
   async function run(jobId: string): Promise<void> {
     const job = jobs.get(jobId);
     if (!job) return;
+
+    if (job.status === "cancelled") {
+      return;
+    }
 
     const controller = new AbortController();
     controllers.set(jobId, controller);
@@ -287,7 +290,7 @@ export function createIndexJobManager(
   function start(options: StartIndexJobOptions): IndexJob {
     prune();
 
-    const existing = getActiveJobByMode(options.mode);
+    const existing = getActiveJob();
     if (existing) {
       return cloneJob(existing);
     }

--- a/src/notes/crud.test.ts
+++ b/src/notes/crud.test.ts
@@ -74,16 +74,32 @@ describe("createNote", () => {
   });
 
   it("should create note successfully", async () => {
-    vi.mocked(runJxa).mockResolvedValueOnce("ok");
+    vi.mocked(runJxa).mockResolvedValueOnce(
+      JSON.stringify({ id: "note-1", title: "New Note", folder: "Work" })
+    );
 
-    await expect(createNote("New Note", "Content", "Work")).resolves.toBeUndefined();
+    await expect(createNote("New Note", "Content", "Work")).resolves.toEqual({
+      id: "note-1",
+      title: "New Note",
+      folder: "Work",
+      requestedTitle: "New Note",
+      titleChanged: false,
+    });
   });
 
   it("should allow duplicate titles (Apple Notes uses IDs)", async () => {
-    vi.mocked(runJxa).mockResolvedValueOnce("ok");
+    vi.mocked(runJxa).mockResolvedValueOnce(
+      JSON.stringify({ id: "note-2", title: "Existing Note", folder: "Notes" })
+    );
 
     // Should not throw even if a note with same title exists
-    await expect(createNote("Existing Note", "Content")).resolves.toBeUndefined();
+    await expect(createNote("Existing Note", "Content")).resolves.toEqual({
+      id: "note-2",
+      title: "Existing Note",
+      folder: "Notes",
+      requestedTitle: "Existing Note",
+      titleChanged: false,
+    });
   });
 });
 
@@ -116,6 +132,7 @@ describe("updateNote", () => {
 
     const result = await updateNote("Test", "New Content");
     expect(result).toEqual({
+      id: "123",
       originalTitle: "Test",
       newTitle: "Test",
       folder: "Work",
@@ -133,6 +150,7 @@ describe("updateNote", () => {
 
     const result = await updateNote("Original Title", "# New Heading\n\nContent");
     expect(result).toEqual({
+      id: "123",
       originalTitle: "Original Title",
       newTitle: "New Heading",
       folder: "Work",
@@ -179,7 +197,11 @@ describe("deleteNote", () => {
     });
     vi.mocked(runJxa).mockResolvedValueOnce("ok");
 
-    await expect(deleteNote("Test")).resolves.toBeUndefined();
+    await expect(deleteNote("Test")).resolves.toEqual({
+      id: "123",
+      title: "Test",
+      folder: "Work",
+    });
   });
 
   it("should include suggestions in error when multiple notes found", async () => {
@@ -221,7 +243,12 @@ describe("moveNote", () => {
     });
     vi.mocked(runJxa).mockResolvedValueOnce("ok");
 
-    await expect(moveNote("Test", "Personal")).resolves.toBeUndefined();
+    await expect(moveNote("Test", "Personal")).resolves.toEqual({
+      id: "123",
+      title: "Test",
+      fromFolder: "Work",
+      toFolder: "Personal",
+    });
   });
 
   it("should include suggestions in error when multiple notes found", async () => {

--- a/src/notes/crud.ts
+++ b/src/notes/crud.ts
@@ -72,7 +72,7 @@ export async function createNote(
   title: string,
   content: string,
   folder?: string
-): Promise<void> {
+): Promise<CreateResult> {
   checkReadOnly();
 
   debug(`Creating note: "${title}" in folder: "${folder || "Notes"}"`);
@@ -85,7 +85,7 @@ export async function createNote(
 
   debug(`HTML content length: ${htmlContent.length}`);
 
-  await runJxa(`
+  const result = await runJxa(`
     const app = Application('Notes');
     const title = ${escapedTitle};
     const content = ${escapedContent};
@@ -109,10 +109,36 @@ export async function createNote(
     const note = app.Note({name: title, body: content});
     targetFolder.notes.push(note);
 
-    return "ok";
-  `);
+    return JSON.stringify({
+      id: note.id(),
+      title: note.name(),
+      folder: targetFolder.name(),
+    });
+  `) as string;
 
-  debug(`Note created: "${title}"`);
+  const created = JSON.parse(result) as {
+    id: string;
+    title: string;
+    folder: string;
+  };
+
+  debug(`Note created: "${created.folder}/${created.title}"`);
+
+  return {
+    id: created.id,
+    title: created.title,
+    folder: created.folder,
+    requestedTitle: title,
+    titleChanged: created.title !== title,
+  };
+}
+
+export interface CreateResult {
+  id: string;
+  title: string;
+  folder: string;
+  requestedTitle: string;
+  titleChanged: boolean;
 }
 
 /**
@@ -120,6 +146,8 @@ export async function createNote(
  * Apple Notes may rename the note based on content (first h1 heading).
  */
 export interface UpdateResult {
+  /** Note ID */
+  id: string;
   /** Original title before update */
   originalTitle: string;
   /** Current title after update (may differ if Apple Notes renamed it) */
@@ -189,6 +217,7 @@ export async function updateNote(title: string, content: string): Promise<Update
   }
 
   return {
+    id: note.id,
     originalTitle,
     newTitle,
     folder,
@@ -206,7 +235,7 @@ export async function updateNote(title: string, content: string): Promise<Update
  * @throws Error if READONLY_MODE is enabled
  * @throws Error if note not found or duplicate titles without folder prefix
  */
-export async function deleteNote(title: string): Promise<void> {
+export async function deleteNote(title: string): Promise<DeleteResult> {
   checkReadOnly();
 
   debug(`Deleting note: "${title}"`);
@@ -232,6 +261,18 @@ export async function deleteNote(title: string): Promise<void> {
   `);
 
   debug(`Note deleted: "${title}"`);
+
+  return {
+    id: note.id,
+    title: note.title,
+    folder: note.folder,
+  };
+}
+
+export interface DeleteResult {
+  id: string;
+  title: string;
+  folder: string;
 }
 
 /**
@@ -242,7 +283,7 @@ export async function deleteNote(title: string): Promise<void> {
  * @throws Error if READONLY_MODE is enabled
  * @throws Error if note not found or target folder not found
  */
-export async function moveNote(title: string, folder: string): Promise<void> {
+export async function moveNote(title: string, folder: string): Promise<MoveResult> {
   checkReadOnly();
 
   debug(`Moving note: "${title}" to folder: "${folder}"`);
@@ -277,6 +318,20 @@ export async function moveNote(title: string, folder: string): Promise<void> {
   `);
 
   debug(`Note moved: "${title}" -> "${folder}"`);
+
+  return {
+    id: note.id,
+    title: note.title,
+    fromFolder: note.folder,
+    toFolder: folder,
+  };
+}
+
+export interface MoveResult {
+  id: string;
+  title: string;
+  fromFolder: string;
+  toFolder: string;
 }
 
 export interface TableEdit {

--- a/src/search/chunk-indexer.ts
+++ b/src/search/chunk-indexer.ts
@@ -8,9 +8,18 @@ import { getChunkStore, type ChunkRecord } from "../db/lancedb.js";
 import { getAllNotesWithFallback, type NoteDetails } from "../notes/read.js";
 import { chunkText } from "../utils/chunker.js";
 import { extractMetadata } from "../graph/extract.js";
-import { DEFAULT_CHUNK_SIZE, DEFAULT_CHUNK_OVERLAP } from "../config/constants.js";
+import {
+  DEFAULT_CHUNK_SIZE,
+  DEFAULT_CHUNK_OVERLAP,
+  getEmbeddingBatchSize,
+} from "../config/constants.js";
 import { createDebugLogger } from "../utils/debug.js";
 import { filterContent, shouldIndexContent } from "../utils/content-filter.js";
+import {
+  type IndexRunOptions,
+  type IndexProgressEvent,
+  throwIfCancelled,
+} from "../indexing/contracts.js";
 
 // Debug logging
 const debug = createDebugLogger("CHUNK-INDEXER");
@@ -46,6 +55,29 @@ interface InternalChunkRecord {
   indexed_at: string;
   tags: string[];
   outlinks: string[];
+}
+
+function chunks<T>(array: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < array.length; i += size) {
+    result.push(array.slice(i, i + size));
+  }
+  return result;
+}
+
+function emitProgress(
+  options: IndexRunOptions,
+  stage: IndexProgressEvent["stage"],
+  current: number,
+  total: number,
+  message: string
+): void {
+  options.onProgress?.({
+    stage,
+    current,
+    total,
+    message,
+  });
 }
 
 /**
@@ -125,13 +157,17 @@ export function chunkNote(note: NoteDetails): InternalChunkRecord[] {
  *
  * @returns ChunkIndexResult with stats
  */
-export async function fullChunkIndex(): Promise<ChunkIndexResult> {
+export async function fullChunkIndex(options: IndexRunOptions = {}): Promise<ChunkIndexResult> {
   const startTime = Date.now();
+  throwIfCancelled(options.signal);
+  emitProgress(options, "fetch", 0, 1, "Fetching notes for chunk index");
 
   // Phase 1: Fetch all notes with hybrid fallback
   debug("Phase 1: Fetching all notes with fallback...");
   const { notes, skipped: skippedNotes } = await getAllNotesWithFallback();
   debug(`Fetched ${notes.length} notes, skipped ${skippedNotes.length}`);
+  emitProgress(options, "fetch", 1, 1, `Fetched ${notes.length} notes`);
+  throwIfCancelled(options.signal);
 
   if (notes.length === 0) {
     return {
@@ -147,10 +183,13 @@ export async function fullChunkIndex(): Promise<ChunkIndexResult> {
   debug("Phase 2: Chunking all notes...");
   const allChunks: InternalChunkRecord[] = [];
   for (const note of notes) {
+    throwIfCancelled(options.signal);
     const noteChunks = chunkNote(note);
     allChunks.push(...noteChunks);
   }
   debug(`Created ${allChunks.length} chunks from ${notes.length} notes`);
+  emitProgress(options, "prepare", allChunks.length, Math.max(notes.length, 1), "Prepared note chunks");
+  throwIfCancelled(options.signal);
 
   if (allChunks.length === 0) {
     return {
@@ -163,9 +202,32 @@ export async function fullChunkIndex(): Promise<ChunkIndexResult> {
 
   // Phase 3: Generate embeddings in batch
   debug("Phase 3: Generating embeddings...");
-  const chunkTexts: string[] = allChunks.map((chunk) => chunk.content);
-  const vectors = await getEmbeddingBatch(chunkTexts);
+  const chunkBatches = chunks(allChunks, getEmbeddingBatchSize());
+  const vectors: number[][] = [];
+  for (let batchIdx = 0; batchIdx < chunkBatches.length; batchIdx++) {
+    throwIfCancelled(options.signal);
+    emitProgress(
+      options,
+      "embed",
+      batchIdx,
+      chunkBatches.length,
+      `Embedding chunk batch ${batchIdx + 1}/${chunkBatches.length}`
+    );
+
+    const batchTexts = chunkBatches[batchIdx].map((chunk) => chunk.content);
+    const batchVectors = await getEmbeddingBatch(batchTexts);
+    vectors.push(...batchVectors);
+
+    emitProgress(
+      options,
+      "embed",
+      batchIdx + 1,
+      chunkBatches.length,
+      `Embedded chunk batch ${batchIdx + 1}/${chunkBatches.length}`
+    );
+  }
   debug(`Generated ${vectors.length} embeddings`);
+  throwIfCancelled(options.signal);
 
   // Phase 4: Combine chunks with vectors and set indexed_at
   debug("Phase 4: Combining chunks with vectors...");
@@ -179,11 +241,14 @@ export async function fullChunkIndex(): Promise<ChunkIndexResult> {
   // Phase 5: Store in LanceDB
   debug("Phase 5: Storing chunks...");
   const chunkStore = getChunkStore();
+  emitProgress(options, "persist", 0, 1, "Storing chunk vectors");
   await chunkStore.indexChunks(completeChunks);
+  emitProgress(options, "persist", 1, 1, "Stored chunk vectors");
   debug(`Stored ${completeChunks.length} chunks`);
 
   const timeMs = Date.now() - startTime;
   debug(`Chunk indexing completed in ${timeMs}ms`);
+  emitProgress(options, "done", 1, 1, "Chunk index completed");
 
   return {
     totalNotes: notes.length,

--- a/src/search/indexer.progress.test.ts
+++ b/src/search/indexer.progress.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockStore = {
+  clear: vi.fn(),
+  index: vi.fn(),
+  addRecords: vi.fn(),
+  rebuildFtsIndex: vi.fn(),
+};
+
+vi.mock("../db/lancedb.js", () => ({
+  getVectorStore: vi.fn(() => mockStore),
+}));
+
+vi.mock("../notes/read.js", () => ({
+  getAllNotesWithFallback: vi.fn().mockResolvedValue({
+    notes: [
+      {
+        id: "n1",
+        title: "Note 1",
+        folder: "Work",
+        content: "content",
+        created: "2026-01-01T00:00:00.000Z",
+        modified: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+    skipped: [],
+  }),
+  getNoteByTitle: vi.fn(),
+}));
+
+vi.mock("../embeddings/index.js", () => ({
+  getEmbedding: vi.fn(),
+  getEmbeddingBatch: vi.fn().mockResolvedValue([[0.1, 0.2, 0.3]]),
+}));
+
+vi.mock("../config/constants.js", () => ({
+  getEmbeddingBatchSize: vi.fn(() => 50),
+}));
+
+vi.mock("../graph/extract.js", () => ({
+  extractMetadata: vi.fn(() => ({ tags: [], outlinks: [] })),
+}));
+
+vi.mock("../utils/text.js", () => ({
+  truncateForEmbedding: vi.fn((content: string) => content),
+}));
+
+vi.mock("../utils/debug.js", () => ({
+  createDebugLogger: vi.fn(() => vi.fn()),
+}));
+
+describe("indexer progress/cancel safety", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not call clear during full index", async () => {
+    const { fullIndex } = await import("./indexer.js");
+
+    await fullIndex();
+
+    expect(mockStore.clear).not.toHaveBeenCalled();
+    expect(mockStore.index).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws cancellation before indexing when signal is already aborted", async () => {
+    const { fullIndex } = await import("./indexer.js");
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(fullIndex({ signal: controller.signal })).rejects.toThrow("Indexing cancelled");
+    expect(mockStore.clear).not.toHaveBeenCalled();
+    expect(mockStore.index).not.toHaveBeenCalled();
+  });
+});

--- a/src/search/indexer.ts
+++ b/src/search/indexer.ts
@@ -191,14 +191,9 @@ export async function fullIndex(options: IndexRunOptions = {}): Promise<IndexRes
 
   const store = getVectorStore();
 
-  // Phase 2: Clear existing index
-  debug("Phase 2: Clearing existing index...");
-  await store.clear();
-  throwIfCancelled(options.signal);
-
-  // Phase 3: Stream process in batches
+  // Phase 2: Stream process in batches
   const batchSize = getEmbeddingBatchSize();
-  debug(`Phase 3: Processing ${preparedNotes.length} notes in batches of ${batchSize}...`);
+  debug(`Phase 2: Processing ${preparedNotes.length} notes in batches of ${batchSize}...`);
 
   const batches = chunks(preparedNotes, batchSize);
   const indexedAt = new Date().toISOString();
@@ -261,8 +256,8 @@ export async function fullIndex(options: IndexRunOptions = {}): Promise<IndexRes
     );
   }
 
-  // Phase 4: Rebuild FTS index (once at end)
-  debug("Phase 4: Rebuilding FTS index...");
+  // Phase 3: Rebuild FTS index (once at end)
+  debug("Phase 3: Rebuilding FTS index...");
   if (totalIndexed > 0) {
     emitProgress(options, "rebuild-fts", 0, 1, "Rebuilding FTS index");
     await store.rebuildFtsIndex();

--- a/src/search/indexer.ts
+++ b/src/search/indexer.ts
@@ -8,7 +8,11 @@
  */
 
 import { getEmbedding, getEmbeddingBatch } from "../embeddings/index.js";
-import { getVectorStore, type NoteRecord } from "../db/lancedb.js";
+import {
+  getVectorStore,
+  type NoteRecord,
+  type IndexMetadataRecord,
+} from "../db/lancedb.js";
 import {
   getAllNotesWithFallback,
   getNoteByTitle,
@@ -18,6 +22,11 @@ import { truncateForEmbedding } from "../utils/text.js";
 import { NoteNotFoundError } from "../errors/index.js";
 import { extractMetadata } from "../graph/extract.js";
 import { getEmbeddingBatchSize } from "../config/constants.js";
+import {
+  type IndexRunOptions,
+  type IndexProgressEvent,
+  throwIfCancelled,
+} from "../indexing/contracts.js";
 
 /**
  * Extract note title from folder/title key.
@@ -134,6 +143,21 @@ function chunks<T>(array: T[], size: number): T[][] {
   return result;
 }
 
+function emitProgress(
+  options: IndexRunOptions,
+  stage: IndexProgressEvent["stage"],
+  current: number,
+  total: number,
+  message: string
+): void {
+  options.onProgress?.({
+    stage,
+    current,
+    total,
+    message,
+  });
+}
+
 /**
  * Perform full reindexing of all notes.
  * Drops existing index and rebuilds from scratch.
@@ -142,14 +166,19 @@ function chunks<T>(array: T[], size: number): T[][] {
  * - Hybrid fallback for JXA fetch (single call → folder → note-by-note)
  * - Streaming batch embedding (process & store in chunks to reduce memory)
  */
-export async function fullIndex(): Promise<IndexResult> {
+export async function fullIndex(options: IndexRunOptions = {}): Promise<IndexResult> {
   const startTime = Date.now();
   debug("Starting full index...");
+
+  throwIfCancelled(options.signal);
+  emitProgress(options, "fetch", 0, 1, "Fetching notes");
 
   // Phase 1: Fetch all notes with hybrid fallback
   debug("Phase 1: Fetching all notes (with fallback)...");
   const { notes: allNotes, skipped: skippedNotes } = await getAllNotesWithFallback();
   debug(`Fetched ${allNotes.length} notes, ${skippedNotes.length} skipped`);
+  emitProgress(options, "fetch", 1, 1, `Fetched ${allNotes.length} notes`);
+  throwIfCancelled(options.signal);
 
   // Filter empty notes and prepare for embedding
   const preparedNotes = allNotes
@@ -157,12 +186,15 @@ export async function fullIndex(): Promise<IndexResult> {
     .filter((note): note is PreparedNote => note !== null);
 
   debug(`Prepared ${preparedNotes.length} notes for embedding`);
+  emitProgress(options, "prepare", preparedNotes.length, allNotes.length, "Prepared notes for embedding");
+  throwIfCancelled(options.signal);
 
   const store = getVectorStore();
 
   // Phase 2: Clear existing index
   debug("Phase 2: Clearing existing index...");
   await store.clear();
+  throwIfCancelled(options.signal);
 
   // Phase 3: Stream process in batches
   const batchSize = getEmbeddingBatchSize();
@@ -174,8 +206,17 @@ export async function fullIndex(): Promise<IndexResult> {
   let isFirstBatch = true;
 
   for (let batchIdx = 0; batchIdx < batches.length; batchIdx++) {
+    throwIfCancelled(options.signal);
+
     const batch = batches[batchIdx];
     debug(`Batch ${batchIdx + 1}/${batches.length}: ${batch.length} notes`);
+    emitProgress(
+      options,
+      "embed",
+      batchIdx,
+      batches.length,
+      `Embedding batch ${batchIdx + 1}/${batches.length}`
+    );
 
     // Generate embeddings for this batch
     const textsToEmbed = batch.map((n) => n.truncatedContent);
@@ -186,6 +227,14 @@ export async function fullIndex(): Promise<IndexResult> {
       debug(`Batch ${batchIdx + 1} embedding failed:`, error);
       throw error;
     }
+    throwIfCancelled(options.signal);
+    emitProgress(
+      options,
+      "embed",
+      batchIdx + 1,
+      batches.length,
+      `Embedded batch ${batchIdx + 1}/${batches.length}`
+    );
 
     // Build records
     const records = batch.map((note, i) =>
@@ -199,20 +248,31 @@ export async function fullIndex(): Promise<IndexResult> {
     } else {
       await store.addRecords(records);
     }
+    throwIfCancelled(options.signal);
 
     totalIndexed += records.length;
     debug(`Batch ${batchIdx + 1} stored, total: ${totalIndexed}`);
+    emitProgress(
+      options,
+      "persist",
+      batchIdx + 1,
+      batches.length,
+      `Stored batch ${batchIdx + 1}/${batches.length}`
+    );
   }
 
   // Phase 4: Rebuild FTS index (once at end)
   debug("Phase 4: Rebuilding FTS index...");
   if (totalIndexed > 0) {
+    emitProgress(options, "rebuild-fts", 0, 1, "Rebuilding FTS index");
     await store.rebuildFtsIndex();
+    emitProgress(options, "rebuild-fts", 1, 1, "FTS index rebuilt");
   }
 
   const timeMs = Date.now() - startTime;
   const emptySkipped = allNotes.length - preparedNotes.length;
   debug(`Full index complete: ${totalIndexed} indexed, ${emptySkipped} empty, ${skippedNotes.length} fetch-skipped, ${timeMs}ms`);
+  emitProgress(options, "done", 1, 1, "Full index completed");
 
   return {
     total: allNotes.length + skippedNotes.length,
@@ -228,29 +288,34 @@ export async function fullIndex(): Promise<IndexResult> {
  * Only processes notes that have changed since last index.
  * Uses batch fetch (getAllNotesWithFallback) instead of individual JXA calls.
  */
-export async function incrementalIndex(): Promise<IndexResult> {
+export async function incrementalIndex(options: IndexRunOptions = {}): Promise<IndexResult> {
   const startTime = Date.now();
   debug("Starting incremental index...");
+
+  throwIfCancelled(options.signal);
+  emitProgress(options, "fetch", 0, 1, "Fetching notes for incremental index");
 
   const store = getVectorStore();
 
   // Get existing indexed notes first
-  let existingRecords: NoteRecord[];
+  let existingRecords: IndexMetadataRecord[];
   try {
-    existingRecords = await store.getAll();
+    existingRecords = await store.getIndexMetadata();
   } catch (error) {
     // No existing index, fall back to full index
     debug("No existing index found, performing full index. Error:", error);
-    return fullIndex();
+    return fullIndex(options);
   }
 
   // Phase 1: Fetch ALL notes with content in batch (hybrid fallback)
   debug("Phase 1: Fetching all notes with fallback...");
   const { notes: allNotesWithContent, skipped: skippedNotes } = await getAllNotesWithFallback();
   debug(`Fetched ${allNotesWithContent.length} notes, skipped ${skippedNotes.length}`);
+  emitProgress(options, "fetch", 1, 1, `Fetched ${allNotesWithContent.length} notes`);
+  throwIfCancelled(options.signal);
 
   // Build lookup maps
-  const existingByKey = new Map<string, NoteRecord>();
+  const existingByKey = new Map<string, IndexMetadataRecord>();
   for (const record of existingRecords) {
     const key = `${record.folder}/${record.title}`;
     existingByKey.set(key, record);
@@ -302,6 +367,7 @@ export async function incrementalIndex(): Promise<IndexResult> {
 
   // Process additions and updates - notes already have content!
   const toProcess = [...toAdd, ...toUpdate];
+  emitProgress(options, "prepare", toProcess.length, allNotesWithContent.length, "Prepared notes to process");
 
   if (toProcess.length > 0) {
     // Phase 2: Prepare notes for embedding (content already fetched)
@@ -309,6 +375,7 @@ export async function incrementalIndex(): Promise<IndexResult> {
     const preparedNotes: PreparedNote[] = [];
 
     for (const noteDetails of toProcess) {
+      throwIfCancelled(options.signal);
       const prepared = prepareNoteForEmbedding(noteDetails);
       if (prepared) {
         preparedNotes.push(prepared);
@@ -318,37 +385,74 @@ export async function incrementalIndex(): Promise<IndexResult> {
     if (preparedNotes.length > 0) {
       // Phase 3: Generate embeddings in batch
       debug(`Phase 3: Generating ${preparedNotes.length} embeddings in batch...`);
-      const textsToEmbed = preparedNotes.map(n => n.truncatedContent);
+      const preparedBatches = chunks(preparedNotes, getEmbeddingBatchSize());
+      let persistedCount = 0;
 
-      let vectors: number[][];
-      try {
-        vectors = await getEmbeddingBatch(textsToEmbed);
-      } catch (error) {
-        debug("Batch embedding failed:", error);
-        throw error;
-      }
+      for (let batchIdx = 0; batchIdx < preparedBatches.length; batchIdx++) {
+        throwIfCancelled(options.signal);
 
-      // Phase 4: Update database
-      debug("Phase 4: Updating database...");
-      const indexedAt = new Date().toISOString();
+        const batch = preparedBatches[batchIdx];
+        emitProgress(
+          options,
+          "embed",
+          batchIdx,
+          preparedBatches.length,
+          `Embedding batch ${batchIdx + 1}/${preparedBatches.length}`
+        );
 
-      for (let i = 0; i < preparedNotes.length; i++) {
-        const note = preparedNotes[i];
-        const record = buildNoteRecord(note, vectors[i], indexedAt);
+        const textsToEmbed = batch.map((n) => n.truncatedContent);
 
+        let vectors: number[][];
         try {
-          await store.update(record);
+          vectors = await getEmbeddingBatch(textsToEmbed);
         } catch (error) {
-          debug(`Error updating ${note.title}:`, error);
-          failedNotes.push(`${note.folder}/${note.title}`);
-          errors++;
+          debug("Batch embedding failed:", error);
+          throw error;
+        }
+
+        emitProgress(
+          options,
+          "embed",
+          batchIdx + 1,
+          preparedBatches.length,
+          `Embedded batch ${batchIdx + 1}/${preparedBatches.length}`
+        );
+
+        // Phase 4: Update database
+        debug("Phase 4: Updating database...");
+        const indexedAt = new Date().toISOString();
+
+        for (let i = 0; i < batch.length; i++) {
+          throwIfCancelled(options.signal);
+
+          const note = batch[i];
+          const record = buildNoteRecord(note, vectors[i], indexedAt);
+
+          try {
+            await store.update(record);
+          } catch (error) {
+            debug(`Error updating ${note.title}:`, error);
+            failedNotes.push(`${note.folder}/${note.title}`);
+            errors++;
+          }
+
+          persistedCount += 1;
+          emitProgress(
+            options,
+            "persist",
+            persistedCount,
+            preparedNotes.length,
+            `Persisted ${persistedCount}/${preparedNotes.length} note updates`
+          );
         }
       }
     }
   }
 
   // Process deletions
-  for (const key of toDelete) {
+  for (let deleteIdx = 0; deleteIdx < toDelete.length; deleteIdx++) {
+    const key = toDelete[deleteIdx];
+    throwIfCancelled(options.signal);
     try {
       // Parse folder and title from key (e.g., "Work/Projects/My Note")
       const lastSlash = key.lastIndexOf("/");
@@ -360,16 +464,27 @@ export async function incrementalIndex(): Promise<IndexResult> {
       failedNotes.push(`DELETE: ${key}`);
       errors++;
     }
+
+    emitProgress(
+      options,
+      "delete",
+      deleteIdx + 1,
+      Math.max(toDelete.length, 1),
+      `Deleted ${deleteIdx + 1}/${toDelete.length} stale records`
+    );
   }
 
   // Rebuild FTS index if any changes were made
   if (toAdd.length > 0 || toUpdate.length > 0 || toDelete.length > 0) {
     debug("Rebuilding FTS index after incremental changes");
+    emitProgress(options, "rebuild-fts", 0, 1, "Rebuilding FTS index");
     await store.rebuildFtsIndex();
+    emitProgress(options, "rebuild-fts", 1, 1, "FTS index rebuilt");
   }
 
   const timeMs = Date.now() - startTime;
   debug(`Incremental index complete: ${timeMs}ms`);
+  emitProgress(options, "done", 1, 1, "Incremental index completed");
 
   return {
     total: allNotesWithContent.length,
@@ -420,10 +535,11 @@ export async function reindexNote(title: string): Promise<void> {
  * Index notes based on mode.
  */
 export async function indexNotes(
-  mode: "full" | "incremental" = "incremental"
+  mode: "full" | "incremental" = "incremental",
+  options: IndexRunOptions = {}
 ): Promise<IndexResult> {
   if (mode === "full") {
-    return fullIndex();
+    return fullIndex(options);
   }
-  return incrementalIndex();
+  return incrementalIndex(options);
 }

--- a/src/search/refresh-policy.test.ts
+++ b/src/search/refresh-policy.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { shouldAutoRefreshByTtl } from "./refresh-policy.js";
+
+describe("shouldAutoRefreshByTtl", () => {
+  it("returns false when INDEX_TTL is not configured", () => {
+    expect(shouldAutoRefreshByTtl(undefined, 2_000_000, 1_000_000)).toBe(false);
+  });
+
+  it("returns false when TTL is invalid", () => {
+    expect(shouldAutoRefreshByTtl("abc", 2_000_000, 1_000_000)).toBe(false);
+    expect(shouldAutoRefreshByTtl("0", 2_000_000, 1_000_000)).toBe(false);
+  });
+
+  it("returns false when TTL has not expired", () => {
+    expect(shouldAutoRefreshByTtl("3600", 2_000_000, 1_999_000)).toBe(false);
+  });
+
+  it("returns true when TTL has expired", () => {
+    expect(shouldAutoRefreshByTtl("60", 2_000_000, 1_000_000)).toBe(true);
+  });
+
+  it("returns true when index is empty and TTL is enabled", () => {
+    expect(shouldAutoRefreshByTtl("60", 2_000_000, null)).toBe(true);
+  });
+});

--- a/src/search/refresh-policy.ts
+++ b/src/search/refresh-policy.ts
@@ -1,0 +1,33 @@
+/**
+ * Refresh policy helpers for search-time auto-refresh.
+ */
+
+/**
+ * Decide whether auto-refresh should run based on TTL.
+ *
+ * Rules:
+ * - No TTL configured => disabled
+ * - Invalid/zero TTL => disabled
+ * - Empty index (no indexed timestamp) => enabled
+ * - Otherwise run only when TTL has expired
+ */
+export function shouldAutoRefreshByTtl(
+  ttlSecondsRaw: string | undefined,
+  nowMs: number,
+  lastIndexedAtMs: number | null
+): boolean {
+  if (!ttlSecondsRaw) {
+    return false;
+  }
+
+  const ttlSeconds = Number.parseInt(ttlSecondsRaw, 10);
+  if (!Number.isFinite(ttlSeconds) || ttlSeconds <= 0) {
+    return false;
+  }
+
+  if (lastIndexedAtMs === null) {
+    return true;
+  }
+
+  return nowMs - lastIndexedAtMs >= ttlSeconds * 1000;
+}

--- a/src/search/refresh.test.ts
+++ b/src/search/refresh.test.ts
@@ -1,15 +1,22 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("../notes/read.js", () => ({
   getAllNotes: vi.fn(),
+  getNoteByFolderAndTitle: vi.fn(),
 }));
 
 vi.mock("../db/lancedb.js", () => ({
   getVectorStore: vi.fn(),
+  getChunkStore: vi.fn(),
 }));
 
 vi.mock("./indexer.js", () => ({
   incrementalIndex: vi.fn(),
+}));
+
+vi.mock("./chunk-indexer.js", () => ({
+  hasChunkIndex: vi.fn().mockResolvedValue(false),
+  updateChunksForNotes: vi.fn(),
 }));
 
 describe("checkForChanges", () => {
@@ -18,7 +25,12 @@ describe("checkForChanges", () => {
     vi.clearAllMocks();
   });
 
-  it("should return true if notes were modified after indexing", async () => {
+  afterEach(() => {
+    delete process.env.INDEX_TTL;
+    delete process.env.SEARCH_REFRESH_TIMEOUT_MS;
+  });
+
+  it("returns true if notes were modified after indexing", async () => {
     const { getAllNotes } = await import("../notes/read.js");
     const { getVectorStore } = await import("../db/lancedb.js");
 
@@ -27,8 +39,8 @@ describe("checkForChanges", () => {
     ]);
 
     vi.mocked(getVectorStore).mockReturnValue({
-      getAll: vi.fn().mockResolvedValue([
-        { title: "Note 1", folder: "Work", indexed_at: "2026-01-09T12:00:00Z" },
+      getIndexMetadata: vi.fn().mockResolvedValue([
+        { id: "1", title: "Note 1", folder: "Work", indexed_at: "2026-01-09T12:00:00Z" },
       ]),
     } as any);
 
@@ -38,7 +50,7 @@ describe("checkForChanges", () => {
     expect(hasChanges).toBe(true);
   });
 
-  it("should return false if no changes", async () => {
+  it("returns false if no changes", async () => {
     const { getAllNotes } = await import("../notes/read.js");
     const { getVectorStore } = await import("../db/lancedb.js");
 
@@ -47,8 +59,8 @@ describe("checkForChanges", () => {
     ]);
 
     vi.mocked(getVectorStore).mockReturnValue({
-      getAll: vi.fn().mockResolvedValue([
-        { title: "Note 1", folder: "Work", indexed_at: "2026-01-09T12:00:00Z" },
+      getIndexMetadata: vi.fn().mockResolvedValue([
+        { id: "1", title: "Note 1", folder: "Work", indexed_at: "2026-01-09T12:00:00Z" },
       ]),
     } as any);
 
@@ -58,7 +70,7 @@ describe("checkForChanges", () => {
     expect(hasChanges).toBe(false);
   });
 
-  it("should return true if new note added", async () => {
+  it("returns true if a new note was added", async () => {
     const { getAllNotes } = await import("../notes/read.js");
     const { getVectorStore } = await import("../db/lancedb.js");
 
@@ -68,8 +80,8 @@ describe("checkForChanges", () => {
     ]);
 
     vi.mocked(getVectorStore).mockReturnValue({
-      getAll: vi.fn().mockResolvedValue([
-        { title: "Note 1", folder: "Work", indexed_at: "2026-01-09T12:00:00Z" },
+      getIndexMetadata: vi.fn().mockResolvedValue([
+        { id: "1", title: "Note 1", folder: "Work", indexed_at: "2026-01-09T12:00:00Z" },
       ]),
     } as any);
 
@@ -79,15 +91,15 @@ describe("checkForChanges", () => {
     expect(hasChanges).toBe(true);
   });
 
-  it("should return true if note deleted", async () => {
+  it("returns true if a note was deleted", async () => {
     const { getAllNotes } = await import("../notes/read.js");
     const { getVectorStore } = await import("../db/lancedb.js");
 
     vi.mocked(getAllNotes).mockResolvedValue([]);
 
     vi.mocked(getVectorStore).mockReturnValue({
-      getAll: vi.fn().mockResolvedValue([
-        { title: "Note 1", folder: "Work", indexed_at: "2026-01-09T12:00:00Z" },
+      getIndexMetadata: vi.fn().mockResolvedValue([
+        { id: "1", title: "Note 1", folder: "Work", indexed_at: "2026-01-09T12:00:00Z" },
       ]),
     } as any);
 
@@ -97,7 +109,7 @@ describe("checkForChanges", () => {
     expect(hasChanges).toBe(true);
   });
 
-  it("should return true if no index exists and notes exist", async () => {
+  it("returns true if no index exists and notes exist", async () => {
     const { getAllNotes } = await import("../notes/read.js");
     const { getVectorStore } = await import("../db/lancedb.js");
 
@@ -106,7 +118,7 @@ describe("checkForChanges", () => {
     ]);
 
     vi.mocked(getVectorStore).mockReturnValue({
-      getAll: vi.fn().mockRejectedValue(new Error("Table not found")),
+      getIndexMetadata: vi.fn().mockRejectedValue(new Error("Table not found")),
     } as any);
 
     const { checkForChanges } = await import("./refresh.js");
@@ -120,19 +132,41 @@ describe("refreshIfNeeded", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    delete process.env.INDEX_TTL;
+    delete process.env.SEARCH_REFRESH_TIMEOUT_MS;
   });
 
-  it("should trigger incremental index if changes detected", async () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("skips refresh when INDEX_TTL is not configured", async () => {
+    const { incrementalIndex } = await import("./indexer.js");
+    const { getVectorStore } = await import("../db/lancedb.js");
+
+    const { refreshIfNeeded } = await import("./refresh.js");
+    const refreshed = await refreshIfNeeded();
+
+    expect(refreshed).toBe(false);
+    expect(incrementalIndex).not.toHaveBeenCalled();
+    expect(getVectorStore).not.toHaveBeenCalled();
+  });
+
+  it("triggers incremental index when TTL expired and changes detected", async () => {
+    process.env.INDEX_TTL = "1";
+
     const { incrementalIndex } = await import("./indexer.js");
     const { getAllNotes } = await import("../notes/read.js");
     const { getVectorStore } = await import("../db/lancedb.js");
 
     vi.mocked(getAllNotes).mockResolvedValue([
-      { title: "New Note", folder: "Work", created: "2026-01-10", modified: "2026-01-10T12:00:00Z" },
+      { title: "Note 1", folder: "Work", created: "2026-01-01", modified: "2026-01-10T12:00:00Z" },
     ]);
 
     vi.mocked(getVectorStore).mockReturnValue({
-      getAll: vi.fn().mockResolvedValue([]),
+      getIndexMetadata: vi.fn().mockResolvedValue([
+        { id: "1", title: "Note 1", folder: "Work", indexed_at: "2020-01-01T00:00:00Z" },
+      ]),
     } as any);
 
     vi.mocked(incrementalIndex).mockResolvedValue({
@@ -146,21 +180,23 @@ describe("refreshIfNeeded", () => {
     const refreshed = await refreshIfNeeded();
 
     expect(refreshed).toBe(true);
-    expect(incrementalIndex).toHaveBeenCalled();
+    expect(incrementalIndex).toHaveBeenCalledOnce();
   });
 
-  it("should not trigger index if no changes", async () => {
+  it("skips refresh when TTL is not expired", async () => {
+    process.env.INDEX_TTL = "86400";
+
     const { incrementalIndex } = await import("./indexer.js");
-    const { getAllNotes } = await import("../notes/read.js");
     const { getVectorStore } = await import("../db/lancedb.js");
 
-    vi.mocked(getAllNotes).mockResolvedValue([
-      { title: "Note 1", folder: "Work", created: "2026-01-01", modified: "2026-01-08T12:00:00Z" },
-    ]);
-
     vi.mocked(getVectorStore).mockReturnValue({
-      getAll: vi.fn().mockResolvedValue([
-        { title: "Note 1", folder: "Work", indexed_at: "2026-01-09T12:00:00Z" },
+      getIndexMetadata: vi.fn().mockResolvedValue([
+        {
+          id: "1",
+          title: "Note 1",
+          folder: "Work",
+          indexed_at: new Date().toISOString(),
+        },
       ]),
     } as any);
 
@@ -169,5 +205,90 @@ describe("refreshIfNeeded", () => {
 
     expect(refreshed).toBe(false);
     expect(incrementalIndex).not.toHaveBeenCalled();
+  });
+
+  it("returns false when refresh throws", async () => {
+    process.env.INDEX_TTL = "1";
+
+    const { incrementalIndex } = await import("./indexer.js");
+    const { getAllNotes } = await import("../notes/read.js");
+    const { getVectorStore } = await import("../db/lancedb.js");
+
+    vi.mocked(getAllNotes).mockRejectedValue(new Error("JXA failed"));
+
+    vi.mocked(getVectorStore).mockReturnValue({
+      getIndexMetadata: vi.fn().mockResolvedValue([
+        { id: "1", title: "Note 1", folder: "Work", indexed_at: "2020-01-01T00:00:00Z" },
+      ]),
+    } as any);
+
+    const { refreshIfNeeded } = await import("./refresh.js");
+    const refreshed = await refreshIfNeeded();
+
+    expect(refreshed).toBe(false);
+    expect(incrementalIndex).not.toHaveBeenCalled();
+  });
+
+  it("returns false when refresh exceeds timeout budget", async () => {
+    vi.useFakeTimers();
+
+    process.env.INDEX_TTL = "1";
+    process.env.SEARCH_REFRESH_TIMEOUT_MS = "5";
+
+    const { incrementalIndex } = await import("./indexer.js");
+    const { getAllNotes } = await import("../notes/read.js");
+    const { getVectorStore } = await import("../db/lancedb.js");
+
+    vi.mocked(getAllNotes).mockResolvedValue([
+      { title: "Note 1", folder: "Work", created: "2026-01-01", modified: "2026-01-10T12:00:00Z" },
+    ]);
+
+    vi.mocked(getVectorStore).mockReturnValue({
+      getIndexMetadata: vi.fn().mockResolvedValue([
+        { id: "1", title: "Note 1", folder: "Work", indexed_at: "2020-01-01T00:00:00Z" },
+      ]),
+    } as any);
+
+    vi.mocked(incrementalIndex).mockImplementation(
+      () => new Promise(() => {
+        // Intentionally never resolves
+      })
+    );
+
+    const { refreshIfNeeded } = await import("./refresh.js");
+    const pending = refreshIfNeeded();
+
+    await vi.advanceTimersByTimeAsync(10);
+    await expect(pending).resolves.toBe(false);
+  });
+
+  it("coalesces concurrent refresh calls into a single run", async () => {
+    process.env.INDEX_TTL = "1";
+
+    const { incrementalIndex } = await import("./indexer.js");
+    const { getAllNotes } = await import("../notes/read.js");
+    const { getVectorStore } = await import("../db/lancedb.js");
+
+    vi.mocked(getAllNotes).mockResolvedValue([
+      { title: "Note 1", folder: "Work", created: "2026-01-01", modified: "2026-01-10T12:00:00Z" },
+    ]);
+
+    vi.mocked(getVectorStore).mockReturnValue({
+      getIndexMetadata: vi.fn().mockResolvedValue([
+        { id: "1", title: "Note 1", folder: "Work", indexed_at: "2020-01-01T00:00:00Z" },
+      ]),
+    } as any);
+
+    vi.mocked(incrementalIndex).mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      return { total: 1, indexed: 1, errors: 0, timeMs: 100 };
+    });
+
+    const { refreshIfNeeded } = await import("./refresh.js");
+    const [first, second] = await Promise.all([refreshIfNeeded(), refreshIfNeeded()]);
+
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+    expect(incrementalIndex).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/search/refresh.ts
+++ b/src/search/refresh.ts
@@ -5,12 +5,26 @@
  */
 
 import { getAllNotes, getNoteByFolderAndTitle, type NoteInfo } from "../notes/read.js";
-import { getVectorStore, getChunkStore } from "../db/lancedb.js";
+import {
+  getVectorStore,
+  getChunkStore,
+  type IndexMetadataRecord,
+} from "../db/lancedb.js";
 import { incrementalIndex } from "./indexer.js";
 import { updateChunksForNotes, hasChunkIndex } from "./chunk-indexer.js";
 import { createDebugLogger } from "../utils/debug.js";
+import { DEFAULT_SEARCH_REFRESH_TIMEOUT_MS } from "../config/constants.js";
+import { shouldAutoRefreshByTtl } from "./refresh-policy.js";
 
 const debug = createDebugLogger("REFRESH");
+let refreshInFlight: Promise<boolean> | null = null;
+
+interface LegacyIndexRecord {
+  id?: string;
+  title: string;
+  folder: string;
+  indexed_at: string;
+}
 
 /**
  * Detected changes in notes.
@@ -22,27 +36,144 @@ interface DetectedChanges {
   deleted: string[]; // note IDs
 }
 
+async function getIndexMetadata(): Promise<IndexMetadataRecord[]> {
+  const store = getVectorStore() as {
+    getIndexMetadata?: () => Promise<IndexMetadataRecord[]>;
+    getAll?: () => Promise<LegacyIndexRecord[]>;
+  };
+
+  if (typeof store.getIndexMetadata === "function") {
+    return store.getIndexMetadata();
+  }
+
+  if (typeof store.getAll === "function") {
+    const legacyRecords = await store.getAll();
+    return legacyRecords.map((record) => ({
+      id: record.id ?? "",
+      title: record.title,
+      folder: record.folder,
+      indexed_at: record.indexed_at,
+    }));
+  }
+
+  throw new Error("Vector store does not expose index metadata methods");
+}
+
+function getLatestIndexedAtMs(records: IndexMetadataRecord[]): number | null {
+  let latestMs: number | null = null;
+
+  for (const record of records) {
+    const indexedAtMs = Date.parse(record.indexed_at);
+    if (Number.isNaN(indexedAtMs)) {
+      continue;
+    }
+    if (latestMs === null || indexedAtMs > latestMs) {
+      latestMs = indexedAtMs;
+    }
+  }
+
+  return latestMs;
+}
+
+function getSearchRefreshTimeoutMs(): number {
+  const raw = process.env.SEARCH_REFRESH_TIMEOUT_MS;
+  if (!raw) {
+    return DEFAULT_SEARCH_REFRESH_TIMEOUT_MS;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_SEARCH_REFRESH_TIMEOUT_MS;
+  }
+
+  return parsed;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | null> {
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutPromise = new Promise<null>((resolve) => {
+    timeoutHandle = setTimeout(() => resolve(null), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeoutHandle !== undefined) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+async function runRefresh(existingRecords: IndexMetadataRecord[]): Promise<boolean> {
+  const changes = await detectChanges(existingRecords);
+
+  if (!changes.hasChanges) {
+    return false;
+  }
+
+  // Update main index
+  debug("Changes detected, running incremental index...");
+  const result = await incrementalIndex();
+  debug(`Main index refresh: ${result.indexed} notes updated in ${result.timeMs}ms`);
+
+  // Update chunk index if it exists and there are changes
+  const hasChunks = await hasChunkIndex();
+  if (hasChunks && (changes.added.length > 0 || changes.modified.length > 0)) {
+    debug("Updating chunk index for changed notes...");
+
+    // Fetch full content for changed notes
+    const changedNotes = [...changes.added, ...changes.modified];
+    const notesWithContent = await Promise.all(
+      changedNotes.map(async (n) => {
+        const note = await getNoteByFolderAndTitle(n.folder, n.title);
+        return note;
+      })
+    );
+
+    // Filter out nulls (notes that couldn't be fetched)
+    const validNotes = notesWithContent.filter((n) => n !== null);
+
+    if (validNotes.length > 0) {
+      const chunksCreated = await updateChunksForNotes(validNotes);
+      debug(`Chunk index refresh: ${chunksCreated} chunks for ${validNotes.length} notes`);
+    }
+
+    // Delete chunks for deleted notes
+    if (changes.deleted.length > 0) {
+      const chunkStore = getChunkStore();
+      await chunkStore.deleteChunksByNoteIds(changes.deleted);
+      debug(`Deleted chunks for ${changes.deleted.length} notes`);
+    }
+  }
+
+  return true;
+}
+
 /**
  * Check for note changes and return details about what changed.
  */
-export async function detectChanges(): Promise<DetectedChanges> {
+export async function detectChanges(
+  existingIndexMetadata?: IndexMetadataRecord[]
+): Promise<DetectedChanges> {
   debug("Checking for changes...");
 
   const currentNotes = await getAllNotes();
-  const store = getVectorStore();
 
-  let existingRecords;
-  try {
-    existingRecords = await store.getAll();
-  } catch {
-    // No index exists yet
-    debug("No existing index found");
-    return {
-      hasChanges: currentNotes.length > 0,
-      added: currentNotes,
-      modified: [],
-      deleted: [],
-    };
+  let existingRecords = existingIndexMetadata;
+  if (!existingRecords) {
+    try {
+      existingRecords = await getIndexMetadata();
+    } catch {
+      // No index exists yet
+      debug("No existing index found");
+      return {
+        hasChanges: currentNotes.length > 0,
+        added: currentNotes,
+        modified: [],
+        deleted: [],
+      };
+    }
   }
 
   // Build lookup maps
@@ -106,46 +237,75 @@ export async function checkForChanges(): Promise<boolean> {
  * @returns true if index was refreshed, false if no changes
  */
 export async function refreshIfNeeded(): Promise<boolean> {
-  const changes = await detectChanges();
+  try {
+    const ttlRaw = process.env.INDEX_TTL;
+    if (!ttlRaw) {
+      debug("Auto-refresh disabled (INDEX_TTL not set)");
+      return false;
+    }
 
-  if (!changes.hasChanges) {
+    const parsedTtlSeconds = Number.parseInt(ttlRaw, 10);
+    if (!Number.isFinite(parsedTtlSeconds) || parsedTtlSeconds <= 0) {
+      debug("Auto-refresh disabled (INDEX_TTL invalid)");
+      return false;
+    }
+
+    const timeoutMs = getSearchRefreshTimeoutMs();
+    if (refreshInFlight) {
+      debug("Auto-refresh already in progress, waiting for existing run");
+      const sharedResult = await withTimeout(refreshInFlight, timeoutMs);
+      if (sharedResult === null) {
+        debug(`Auto-refresh wait timed out after ${timeoutMs}ms; returning stale index results`);
+        return false;
+      }
+      return sharedResult;
+    }
+
+    const refreshTask = (async () => {
+      let existingRecords: IndexMetadataRecord[] = [];
+
+      try {
+        existingRecords = await getIndexMetadata();
+      } catch {
+        // No index yet - treat as empty metadata
+        existingRecords = [];
+      }
+
+      const lastIndexedAtMs = getLatestIndexedAtMs(existingRecords);
+      const shouldRefresh = shouldAutoRefreshByTtl(
+        ttlRaw,
+        Date.now(),
+        lastIndexedAtMs
+      );
+
+      if (!shouldRefresh) {
+        debug("Auto-refresh skipped by TTL policy");
+        return false;
+      }
+
+      return runRefresh(existingRecords);
+    })()
+      .catch((error) => {
+        debug("Auto-refresh failed; returning stale index results", error);
+        return false;
+      })
+      .finally(() => {
+        if (refreshInFlight === refreshTask) {
+          refreshInFlight = null;
+        }
+      });
+
+    refreshInFlight = refreshTask;
+
+    const refreshed = await withTimeout(refreshTask, timeoutMs);
+    if (refreshed === null) {
+      debug(`Auto-refresh timed out after ${timeoutMs}ms; returning stale index results`);
+      return false;
+    }
+
+    return refreshed;
+  } catch (error) {
+    debug("Unexpected auto-refresh failure; returning stale index results", error);
     return false;
   }
-
-  // Update main index
-  debug("Changes detected, running incremental index...");
-  const result = await incrementalIndex();
-  debug(`Main index refresh: ${result.indexed} notes updated in ${result.timeMs}ms`);
-
-  // Update chunk index if it exists and there are changes
-  const hasChunks = await hasChunkIndex();
-  if (hasChunks && (changes.added.length > 0 || changes.modified.length > 0)) {
-    debug("Updating chunk index for changed notes...");
-
-    // Fetch full content for changed notes
-    const changedNotes = [...changes.added, ...changes.modified];
-    const notesWithContent = await Promise.all(
-      changedNotes.map(async (n) => {
-        const note = await getNoteByFolderAndTitle(n.folder, n.title);
-        return note;
-      })
-    );
-
-    // Filter out nulls (notes that couldn't be fetched)
-    const validNotes = notesWithContent.filter((n) => n !== null);
-
-    if (validNotes.length > 0) {
-      const chunksCreated = await updateChunksForNotes(validNotes);
-      debug(`Chunk index refresh: ${chunksCreated} chunks for ${validNotes.length} notes`);
-    }
-
-    // Delete chunks for deleted notes
-    if (changes.deleted.length > 0) {
-      const chunkStore = getChunkStore();
-      await chunkStore.deleteChunksByNoteIds(changes.deleted);
-      debug(`Deleted chunks for ${changes.deleted.length} notes`);
-    }
-  }
-
-  return true;
 }

--- a/src/search/write-sync.test.ts
+++ b/src/search/write-sync.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockVectorStore = {
   deleteByFolderAndTitle: vi.fn(),
+  deleteByIdAndFolderAndTitle: vi.fn(),
 };
 
 const mockChunkStore = {
@@ -70,7 +71,7 @@ describe("write-sync", () => {
       folder: "Work",
     });
 
-    expect(mockVectorStore.deleteByFolderAndTitle).toHaveBeenCalledWith("Work", "A");
+    expect(mockVectorStore.deleteByIdAndFolderAndTitle).toHaveBeenCalledWith("note-1", "Work", "A");
     expect(mockChunkStore.deleteChunksByNoteIds).toHaveBeenCalledWith(["note-1"]);
     expect(result.ok).toBe(true);
   });
@@ -86,7 +87,7 @@ describe("write-sync", () => {
       toFolder: "Archive",
     });
 
-    expect(mockVectorStore.deleteByFolderAndTitle).toHaveBeenCalledWith("Work", "A");
+    expect(mockVectorStore.deleteByIdAndFolderAndTitle).toHaveBeenCalledWith("note-1", "Work", "A");
     expect(reindexNote).toHaveBeenCalledWith("id:note-1");
     expect(result.ok).toBe(true);
   });
@@ -103,8 +104,30 @@ describe("write-sync", () => {
       titleChanged: true,
     });
 
-    expect(mockVectorStore.deleteByFolderAndTitle).toHaveBeenCalledWith("Work", "Old A");
+    expect(mockVectorStore.deleteByIdAndFolderAndTitle).toHaveBeenCalledWith("note-1", "Work", "Old A");
     expect(reindexNote).toHaveBeenCalledWith("id:note-1");
     expect(result.ok).toBe(true);
+  });
+
+  it("reindexes before stale cleanup on move", async () => {
+    const { syncAfterMove } = await import("./write-sync.js");
+    const { reindexNote } = await import("./indexer.js");
+
+    const order: string[] = [];
+    vi.mocked(reindexNote).mockImplementation(async () => {
+      order.push("reindex");
+    });
+    mockVectorStore.deleteByIdAndFolderAndTitle.mockImplementation(async () => {
+      order.push("cleanup");
+    });
+
+    await syncAfterMove({
+      id: "note-1",
+      title: "A",
+      fromFolder: "Work",
+      toFolder: "Archive",
+    });
+
+    expect(order).toEqual(["reindex", "cleanup"]);
   });
 });

--- a/src/search/write-sync.test.ts
+++ b/src/search/write-sync.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockVectorStore = {
+  deleteByFolderAndTitle: vi.fn(),
+};
+
+const mockChunkStore = {
+  deleteChunksByNoteIds: vi.fn(),
+};
+
+vi.mock("../db/lancedb.js", () => ({
+  getVectorStore: vi.fn(() => mockVectorStore),
+  getChunkStore: vi.fn(() => mockChunkStore),
+}));
+
+vi.mock("./indexer.js", () => ({
+  reindexNote: vi.fn(),
+}));
+
+vi.mock("./chunk-indexer.js", () => ({
+  hasChunkIndex: vi.fn().mockResolvedValue(true),
+  updateChunksForNotes: vi.fn(),
+}));
+
+vi.mock("../notes/read.js", () => ({
+  getNoteById: vi.fn().mockResolvedValue({
+    id: "note-1",
+    title: "A",
+    folder: "Work",
+    content: "Content",
+    htmlContent: "<p>Content</p>",
+    created: "2026-01-01T00:00:00.000Z",
+    modified: "2026-01-01T00:00:00.000Z",
+  }),
+}));
+
+vi.mock("../utils/debug.js", () => ({
+  createDebugLogger: vi.fn(() => vi.fn()),
+}));
+
+describe("write-sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("syncAfterCreate reindexes vector and chunks by note id", async () => {
+    const { syncAfterCreate } = await import("./write-sync.js");
+    const { reindexNote } = await import("./indexer.js");
+    const { updateChunksForNotes } = await import("./chunk-indexer.js");
+
+    const result = await syncAfterCreate({
+      id: "note-1",
+      title: "A",
+      folder: "Work",
+      requestedTitle: "A",
+      titleChanged: false,
+    });
+
+    expect(reindexNote).toHaveBeenCalledWith("id:note-1");
+    expect(updateChunksForNotes).toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+  });
+
+  it("syncAfterDelete removes vector and chunk records", async () => {
+    const { syncAfterDelete } = await import("./write-sync.js");
+
+    const result = await syncAfterDelete({
+      id: "note-1",
+      title: "A",
+      folder: "Work",
+    });
+
+    expect(mockVectorStore.deleteByFolderAndTitle).toHaveBeenCalledWith("Work", "A");
+    expect(mockChunkStore.deleteChunksByNoteIds).toHaveBeenCalledWith(["note-1"]);
+    expect(result.ok).toBe(true);
+  });
+
+  it("syncAfterMove deletes old folder/title and reindexes by id", async () => {
+    const { syncAfterMove } = await import("./write-sync.js");
+    const { reindexNote } = await import("./indexer.js");
+
+    const result = await syncAfterMove({
+      id: "note-1",
+      title: "A",
+      fromFolder: "Work",
+      toFolder: "Archive",
+    });
+
+    expect(mockVectorStore.deleteByFolderAndTitle).toHaveBeenCalledWith("Work", "A");
+    expect(reindexNote).toHaveBeenCalledWith("id:note-1");
+    expect(result.ok).toBe(true);
+  });
+
+  it("syncAfterUpdate deletes stale title entry when renamed", async () => {
+    const { syncAfterUpdate } = await import("./write-sync.js");
+    const { reindexNote } = await import("./indexer.js");
+
+    const result = await syncAfterUpdate({
+      id: "note-1",
+      originalTitle: "Old A",
+      newTitle: "New A",
+      folder: "Work",
+      titleChanged: true,
+    });
+
+    expect(mockVectorStore.deleteByFolderAndTitle).toHaveBeenCalledWith("Work", "Old A");
+    expect(reindexNote).toHaveBeenCalledWith("id:note-1");
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/search/write-sync.ts
+++ b/src/search/write-sync.ts
@@ -76,21 +76,24 @@ export async function syncAfterCreate(createResult: CreateResult): Promise<Write
 export async function syncAfterUpdate(updateResult: UpdateResult): Promise<WriteSyncResult> {
   const warnings: Array<string | null> = [];
 
-  // If title changed, remove stale vector entries under old folder/title key.
-  if (updateResult.titleChanged) {
+  const reindexWarning = await trySync("vector-reindex", async () => {
+    await reindexNote(`id:${updateResult.id}`);
+  });
+  warnings.push(reindexWarning);
+
+  // If title changed, remove stale vector entries only after successful reindex.
+  if (updateResult.titleChanged && reindexWarning === null) {
     warnings.push(
       await trySync("vector-delete-old-title", async () => {
         const store = getVectorStore();
-        await store.deleteByFolderAndTitle(updateResult.folder, updateResult.originalTitle);
+        await store.deleteByIdAndFolderAndTitle(
+          updateResult.id,
+          updateResult.folder,
+          updateResult.originalTitle
+        );
       })
     );
   }
-
-  warnings.push(
-    await trySync("vector-reindex", async () => {
-      await reindexNote(`id:${updateResult.id}`);
-    })
-  );
 
   warnings.push(await syncChunksForNoteId(updateResult.id));
 
@@ -103,7 +106,11 @@ export async function syncAfterDelete(deleteResult: DeleteResult): Promise<Write
   warnings.push(
     await trySync("vector-delete", async () => {
       const store = getVectorStore();
-      await store.deleteByFolderAndTitle(deleteResult.folder, deleteResult.title);
+      await store.deleteByIdAndFolderAndTitle(
+        deleteResult.id,
+        deleteResult.folder,
+        deleteResult.title
+      );
     })
   );
 
@@ -124,18 +131,23 @@ export async function syncAfterDelete(deleteResult: DeleteResult): Promise<Write
 export async function syncAfterMove(moveResult: MoveResult): Promise<WriteSyncResult> {
   const warnings: Array<string | null> = [];
 
-  warnings.push(
-    await trySync("vector-delete-old-folder", async () => {
-      const store = getVectorStore();
-      await store.deleteByFolderAndTitle(moveResult.fromFolder, moveResult.title);
-    })
-  );
+  const reindexWarning = await trySync("vector-reindex", async () => {
+    await reindexNote(`id:${moveResult.id}`);
+  });
+  warnings.push(reindexWarning);
 
-  warnings.push(
-    await trySync("vector-reindex", async () => {
-      await reindexNote(`id:${moveResult.id}`);
-    })
-  );
+  if (reindexWarning === null) {
+    warnings.push(
+      await trySync("vector-delete-old-folder", async () => {
+        const store = getVectorStore();
+        await store.deleteByIdAndFolderAndTitle(
+          moveResult.id,
+          moveResult.fromFolder,
+          moveResult.title
+        );
+      })
+    );
+  }
 
   warnings.push(await syncChunksForNoteId(moveResult.id));
 

--- a/src/search/write-sync.ts
+++ b/src/search/write-sync.ts
@@ -1,0 +1,143 @@
+import { getVectorStore, getChunkStore } from "../db/lancedb.js";
+import { getNoteById } from "../notes/read.js";
+import {
+  hasChunkIndex,
+  updateChunksForNotes,
+} from "./chunk-indexer.js";
+import { reindexNote } from "./indexer.js";
+import type {
+  CreateResult,
+  DeleteResult,
+  MoveResult,
+  UpdateResult,
+} from "../notes/crud.js";
+import { createDebugLogger } from "../utils/debug.js";
+
+const debug = createDebugLogger("WRITE-SYNC");
+
+export interface WriteSyncResult {
+  ok: boolean;
+  warnings: string[];
+}
+
+async function trySync(action: string, operation: () => Promise<void>): Promise<string | null> {
+  try {
+    await operation();
+    return null;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    debug(`Write sync step failed (${action}):`, error);
+    return `${action}: ${message}`;
+  }
+}
+
+async function syncChunksForNoteId(noteId: string): Promise<string | null> {
+  try {
+    const hasChunks = await hasChunkIndex();
+    if (!hasChunks) {
+      return null;
+    }
+
+    const note = await getNoteById(noteId);
+    if (!note) {
+      return `chunk-sync: note not found for id ${noteId}`;
+    }
+
+    await updateChunksForNotes([note]);
+    return null;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return `chunk-sync: ${message}`;
+  }
+}
+
+function toResult(warnings: Array<string | null>): WriteSyncResult {
+  const filtered = warnings.filter((w): w is string => w !== null);
+  return {
+    ok: filtered.length === 0,
+    warnings: filtered,
+  };
+}
+
+export async function syncAfterCreate(createResult: CreateResult): Promise<WriteSyncResult> {
+  const warnings: Array<string | null> = [];
+
+  warnings.push(
+    await trySync("vector-reindex", async () => {
+      await reindexNote(`id:${createResult.id}`);
+    })
+  );
+
+  warnings.push(await syncChunksForNoteId(createResult.id));
+
+  return toResult(warnings);
+}
+
+export async function syncAfterUpdate(updateResult: UpdateResult): Promise<WriteSyncResult> {
+  const warnings: Array<string | null> = [];
+
+  // If title changed, remove stale vector entries under old folder/title key.
+  if (updateResult.titleChanged) {
+    warnings.push(
+      await trySync("vector-delete-old-title", async () => {
+        const store = getVectorStore();
+        await store.deleteByFolderAndTitle(updateResult.folder, updateResult.originalTitle);
+      })
+    );
+  }
+
+  warnings.push(
+    await trySync("vector-reindex", async () => {
+      await reindexNote(`id:${updateResult.id}`);
+    })
+  );
+
+  warnings.push(await syncChunksForNoteId(updateResult.id));
+
+  return toResult(warnings);
+}
+
+export async function syncAfterDelete(deleteResult: DeleteResult): Promise<WriteSyncResult> {
+  const warnings: Array<string | null> = [];
+
+  warnings.push(
+    await trySync("vector-delete", async () => {
+      const store = getVectorStore();
+      await store.deleteByFolderAndTitle(deleteResult.folder, deleteResult.title);
+    })
+  );
+
+  warnings.push(
+    await trySync("chunk-delete", async () => {
+      const hasChunks = await hasChunkIndex();
+      if (!hasChunks) {
+        return;
+      }
+      const chunkStore = getChunkStore();
+      await chunkStore.deleteChunksByNoteIds([deleteResult.id]);
+    })
+  );
+
+  return toResult(warnings);
+}
+
+export async function syncAfterMove(moveResult: MoveResult): Promise<WriteSyncResult> {
+  const warnings: Array<string | null> = [];
+
+  warnings.push(
+    await trySync("vector-delete-old-folder", async () => {
+      const store = getVectorStore();
+      await store.deleteByFolderAndTitle(moveResult.fromFolder, moveResult.title);
+    })
+  );
+
+  warnings.push(
+    await trySync("vector-reindex", async () => {
+      await reindexNote(`id:${moveResult.id}`);
+    })
+  );
+
+  warnings.push(await syncChunksForNoteId(moveResult.id));
+
+  return toResult(warnings);
+}


### PR DESCRIPTION
## Summary
- make `search-notes` fail open with TTL-gated refresh and timeout budget, and reduce refresh/index diff cost with metadata-only reads
- keep indexes consistent after note writes by syncing vector/chunk records after create, update, delete, and move operations
- add background indexing job orchestration with granular progress phases, cancellation support (`cancel-index-job`), and new indexing contracts/tests
- update README and changelog with clearer indexing behavior, job lifecycle states, and troubleshooting guidance

## Code Review Fixes
- prevent queued-cancel race: cancelled queued jobs no longer start
- prevent cross-mode concurrency: only one active indexing job runs at a time
- remove destructive `fullIndex` clear-before-cancel path to avoid accidental empty index state
- switch write-sync stale cleanup to ID-scoped deletion and reorder to `reindex -> cleanup`
- restore backward-compatible synchronous default for `index-notes` unless `background: true` is explicit

## Why
Long indexing operations and search-time refreshes could block or time out. This change makes indexing observable and controllable, while ensuring search results stay accurate after write operations.

## Verification
- `bun run check`
- `bun run test`