### PR TITLE
fix: speed up list-notes folder filtering and document v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-02-07
+
+### Fixed
+
+- `list-notes` with `folder` now queries only matching folders instead of loading all notes first
+- Preserved correctness for duplicate folder names across accounts by aggregating all matching folders
+
+### Changed
+
+- Improved `list-notes` folder performance by ~10x on larger vaults (single-folder lookup path)
+
 ## [1.8.0] - 2026-02-06
 
 ### Added
@@ -161,7 +172,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Read-only mode via `READONLY_MODE` env variable
 - Debug logging via `DEBUG` env variable
 
-[Unreleased]: https://github.com/disco-trooper/apple-notes-mcp/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/disco-trooper/apple-notes-mcp/compare/v1.8.1...HEAD
+[1.8.1]: https://github.com/disco-trooper/apple-notes-mcp/compare/v1.8.0...v1.8.1
+[1.8.0]: https://github.com/disco-trooper/apple-notes-mcp/compare/v1.7.0...v1.8.0
+[1.7.0]: https://github.com/disco-trooper/apple-notes-mcp/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/disco-trooper/apple-notes-mcp/compare/v1.5.1...v1.6.0
 [1.5.1]: https://github.com/disco-trooper/apple-notes-mcp/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/disco-trooper/apple-notes-mcp/compare/v1.4.0...v1.5.0

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ MCP server for Apple Notes with semantic search and CRUD operations. Claude sear
 - **Background Index Jobs** - Async full/incremental indexing with progress polling
 - **Dual Embedding** - Local HuggingFace or OpenRouter API
 
-## What's New in 1.7
+## What's New in 1.8.1
 
-- **Hybrid Fallback Indexing** - Recovers from failures by falling back: single call → folder batch → note-by-note
-- **Streaming Batches** - Processes embeddings in batches to reduce peak memory
-- **Skipped Notes Reporting** - Shows which notes failed (locked, syncing, corrupted)
+- **Faster `list-notes` folder filtering** - `list-notes` now queries only the requested folder instead of scanning all notes first
+- **Duplicate folder name correctness** - Folder filtering now aggregates matching folders across accounts
+- **Large vault performance** - Folder-scoped listing is significantly faster on larger note libraries
 
 ## Installation
 
@@ -130,6 +130,8 @@ order: "desc"            # asc or desc (default: desc)
 limit: 10                # max notes to return (1-100)
 folder: "Work"           # filter by folder (case-insensitive)
 ```
+
+When `folder` is provided, the server fetches only matching folders from Apple Notes. This keeps folder-scoped requests fast even when your vault has hundreds of notes.
 
 **Examples:**
 - Get 5 newest notes: `{ sort_by: "created", order: "desc", limit: 5 }`

--- a/src/notes/read.test.ts
+++ b/src/notes/read.test.ts
@@ -6,7 +6,7 @@ vi.mock("run-jxa", () => ({
 }));
 
 import { runJxa } from "run-jxa";
-import { getAllNotes, getNoteByTitle, getAllFolders, resolveNoteTitle, listNotes } from "./read.js";
+import { getAllNotes, getNoteByTitle, getAllFolders, resolveNoteTitle, listNotes, getNoteMetadataByFolder } from "./read.js";
 
 describe("getAllNotes", () => {
   beforeEach(() => {
@@ -243,8 +243,12 @@ describe("listNotes", () => {
     expect(notes[2].title).toBe("Alpha");
   });
 
-  it("should filter by folder", async () => {
-    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify(mockNotes));
+  it("should filter by folder (uses getNoteMetadataByFolder)", async () => {
+    const workNotes = [
+      { title: "Alpha", folder: "Work", created: "2024-01-01T00:00:00Z", modified: "2024-01-10T00:00:00Z" },
+      { title: "Gamma", folder: "Work", created: "2024-01-02T00:00:00Z", modified: "2024-01-15T00:00:00Z" },
+    ];
+    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify(workNotes));
 
     const notes = await listNotes({ folder: "Work" });
     expect(notes).toHaveLength(2);
@@ -259,7 +263,11 @@ describe("listNotes", () => {
   });
 
   it("should combine folder filter and limit", async () => {
-    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify(mockNotes));
+    const workNotes = [
+      { title: "Alpha", folder: "Work", created: "2024-01-01T00:00:00Z", modified: "2024-01-10T00:00:00Z" },
+      { title: "Gamma", folder: "Work", created: "2024-01-02T00:00:00Z", modified: "2024-01-15T00:00:00Z" },
+    ];
+    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify(workNotes));
 
     const notes = await listNotes({ folder: "Work", limit: 1 });
     expect(notes).toHaveLength(1);
@@ -267,7 +275,7 @@ describe("listNotes", () => {
   });
 
   it("should return empty array when folder has no notes", async () => {
-    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify(mockNotes));
+    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify([]));
 
     const notes = await listNotes({ folder: "NonExistent" });
     expect(notes).toHaveLength(0);
@@ -343,5 +351,131 @@ describe("listNotes", () => {
     expect(notes[0].title).toBe("Empty");
     expect(notes[1].title).toBe("Old");
     expect(notes[2].title).toBe("Recent");
+  });
+});
+
+describe("getNoteMetadataByFolder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return notes from the specified folder", async () => {
+    const folderNotes = [
+      { title: "Note A", folder: "Projects", created: "2024-01-01T00:00:00Z", modified: "2024-01-02T00:00:00Z" },
+      { title: "Note B", folder: "Projects", created: "2024-01-03T00:00:00Z", modified: "2024-01-04T00:00:00Z" },
+    ];
+    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify(folderNotes));
+
+    const notes = await getNoteMetadataByFolder("Projects");
+    expect(notes).toHaveLength(2);
+    expect(notes[0].title).toBe("Note A");
+    expect(notes[1].folder).toBe("Projects");
+  });
+
+  it("should return empty array when folder has no notes", async () => {
+    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify([]));
+
+    const notes = await getNoteMetadataByFolder("Empty");
+    expect(notes).toHaveLength(0);
+  });
+
+  it("should return metadata without content fields", async () => {
+    const folderNotes = [
+      { title: "Note", folder: "Work", created: "2024-01-01T00:00:00Z", modified: "2024-01-02T00:00:00Z" },
+    ];
+    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify(folderNotes));
+
+    const notes = await getNoteMetadataByFolder("Work");
+    expect(notes[0]).toHaveProperty("title");
+    expect(notes[0]).toHaveProperty("folder");
+    expect(notes[0]).toHaveProperty("created");
+    expect(notes[0]).toHaveProperty("modified");
+    expect(notes[0]).not.toHaveProperty("content");
+    expect(notes[0]).not.toHaveProperty("htmlContent");
+    expect(notes[0]).not.toHaveProperty("id");
+  });
+
+  it("should aggregate notes from duplicate folder names", async () => {
+    const duplicateFolderNotes = [
+      { title: "A1", folder: "Work", created: "2024-01-01T00:00:00Z", modified: "2024-01-02T00:00:00Z" },
+      { title: "A2", folder: "Work", created: "2024-01-03T00:00:00Z", modified: "2024-01-04T00:00:00Z" },
+    ];
+    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify(duplicateFolderNotes));
+
+    const notes = await getNoteMetadataByFolder("Work");
+    expect(notes).toHaveLength(2);
+    expect(notes.map((n) => n.title)).toEqual(["A1", "A2"]);
+
+    const jxaCode = vi.mocked(runJxa).mock.calls[0][0] as string;
+    expect(jxaCode).not.toContain("break;");
+  });
+});
+
+describe("listNotes folder optimization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should make only one JXA call when folder is specified", async () => {
+    const folderNotes = [
+      { title: "Note 1", folder: "xx", created: "2024-01-01T00:00:00Z", modified: "2024-01-02T00:00:00Z" },
+    ];
+    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify(folderNotes));
+
+    await listNotes({ folder: "xx" });
+    expect(runJxa).toHaveBeenCalledTimes(1);
+
+    const jxaCode = vi.mocked(runJxa).mock.calls[0][0] as string;
+    expect(jxaCode).toContain("targetFolder");
+    expect(jxaCode).toContain("toLowerCase");
+  });
+
+  it("should not fetch all notes when folder is specified", async () => {
+    const folderNotes = [
+      { title: "Only One", folder: "Tiny", created: "2024-01-01T00:00:00Z", modified: "2024-01-02T00:00:00Z" },
+    ];
+    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify(folderNotes));
+
+    const notes = await listNotes({ folder: "Tiny" });
+    expect(notes).toHaveLength(1);
+    expect(notes[0].title).toBe("Only One");
+  });
+
+  it("should use getAllNotes when no folder is specified", async () => {
+    const allNotes = [
+      { title: "A", folder: "Work", created: "2024-01-01T00:00:00Z", modified: "2024-01-02T00:00:00Z" },
+      { title: "B", folder: "Personal", created: "2024-01-03T00:00:00Z", modified: "2024-01-04T00:00:00Z" },
+    ];
+    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify(allNotes));
+
+    const notes = await listNotes();
+    expect(notes).toHaveLength(2);
+    expect(runJxa).toHaveBeenCalledTimes(1);
+
+    const jxaCode = vi.mocked(runJxa).mock.calls[0][0] as string;
+    expect(jxaCode).not.toContain("targetFolder");
+  });
+
+  it("should still sort folder-filtered results", async () => {
+    const folderNotes = [
+      { title: "Old", folder: "Work", created: "2024-01-01T00:00:00Z", modified: "2024-01-05T00:00:00Z" },
+      { title: "New", folder: "Work", created: "2024-01-02T00:00:00Z", modified: "2024-01-15T00:00:00Z" },
+    ];
+    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify(folderNotes));
+
+    const notes = await listNotes({ folder: "Work", sort_by: "modified", order: "desc" });
+    expect(notes[0].title).toBe("New");
+    expect(notes[1].title).toBe("Old");
+  });
+
+  it("should match folder case-insensitively in optimized path", async () => {
+    const workNotes = [
+      { title: "Case Note", folder: "Work", created: "2024-01-01T00:00:00Z", modified: "2024-01-02T00:00:00Z" },
+    ];
+    vi.mocked(runJxa).mockResolvedValueOnce(JSON.stringify(workNotes));
+
+    const notes = await listNotes({ folder: "work" });
+    expect(notes).toHaveLength(1);
+    expect(notes[0].folder).toBe("Work");
   });
 });

--- a/src/notes/read.ts
+++ b/src/notes/read.ts
@@ -620,7 +620,63 @@ export type { ListNotesOptions } from "../index.js";
 import type { ListNotesOptions } from "../index.js";
 
 /**
+ * Get notes metadata from a specific folder (no content).
+ * Much faster than getAllNotes() when only one folder is needed,
+ * because it skips iterating all other folders in JXA.
+ *
+ * @param folderName - The folder name (case-insensitive matching)
+ * @returns Array of note metadata from the specified folder
+ */
+export async function getNoteMetadataByFolder(folderName: string): Promise<NoteInfo[]> {
+  debug(`Getting note metadata for folder: ${folderName}`);
+
+  const escapedFolder = JSON.stringify(folderName);
+
+  const jxaCode = `
+    const app = Application('Notes');
+    app.includeStandardAdditions = true;
+
+    const targetFolder = ${escapedFolder}.toLowerCase();
+    const result = [];
+    const folders = app.folders();
+
+    for (const folder of folders) {
+      const folderName = folder.name();
+      if (folderName.toLowerCase() !== targetFolder) continue;
+
+      const notes = folder.notes();
+
+      for (const note of notes) {
+        try {
+          const props = note.properties();
+          result.push({
+            title: props.name || '',
+            folder: folderName,
+            created: props.creationDate ? props.creationDate.toISOString() : '',
+            modified: props.modificationDate ? props.modificationDate.toISOString() : ''
+          });
+        } catch (e) {
+          // Skip notes that can't be accessed
+        }
+      }
+    }
+
+    return JSON.stringify(result);
+  `;
+
+  const result = await executeJxa<string>(jxaCode);
+  const notes = JSON.parse(result) as NoteInfo[];
+
+  debug(`Found ${notes.length} notes in folder: ${folderName}`);
+  return notes;
+}
+
+/**
  * List notes with sorting and filtering.
+ *
+ * When a folder filter is provided, only that folder is queried via JXA
+ * instead of fetching all notes first. This is significantly faster for
+ * users with many notes spread across folders.
  *
  * @param options - Sorting and filtering options
  * @returns Array of note metadata sorted and filtered as specified
@@ -630,12 +686,9 @@ export async function listNotes(options: ListNotesOptions = {}): Promise<NoteInf
 
   debug(`Listing notes: sort_by=${sort_by}, order=${order}, limit=${limit}, folder=${folder}`);
 
-  const allNotes = await getAllNotes();
-
-  // Filter by folder (case-insensitive for better UX)
   const filtered = folder
-    ? allNotes.filter((n) => n.folder.toLowerCase() === folder.toLowerCase())
-    : allNotes;
+    ? await getNoteMetadataByFolder(folder)
+    : await getAllNotes();
 
   filtered.sort((a, b) => {
     let comparison: number;


### PR DESCRIPTION
## Summary
- switch `listNotes({ folder })` to a folder-scoped JXA path so it does not scan every note first
- preserve correctness for duplicate folder names by aggregating all folder matches across accounts
- update tests, changelog, and README for the v1.8.1 release notes and behavior

## Verification
- `bun run check`
- `bun run test`
- manual benchmark: ~10.89x faster folder-scoped listing in a 364-note vault

Closes #5